### PR TITLE
fix: apply data-theme to document element in ThemeSwitcher hook

### DIFF
--- a/apps/phoenix_duskmoon/assets/js/hooks/theme_switcher.js
+++ b/apps/phoenix_duskmoon/assets/js/hooks/theme_switcher.js
@@ -2,11 +2,26 @@
  * ThemeSwitcher Hook
  * Handles theme switching with localStorage persistence.
  * Works with @duskmoon-dev/core's theme-controller-dropdown CSS component.
+ *
+ * Sets data-theme on document.documentElement so CSS attribute selectors
+ * like [data-theme="sunshine"] activate the correct theme.
  */
+
+function applyTheme(theme) {
+  if (theme && theme !== "default") {
+    document.documentElement.setAttribute("data-theme", theme);
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
 export const ThemeSwitcher = {
   mounted() {
     const serverTheme = this.el.dataset.theme || "";
     let theme = serverTheme || localStorage.getItem("theme") || "default";
+
+    // Apply theme to document root so CSS selectors activate
+    applyTheme(theme);
 
     const themeInputs = this.el.querySelectorAll(".theme-controller-item");
 
@@ -21,6 +36,7 @@ export const ThemeSwitcher = {
       const listener = (event) => {
         theme = event.target.value;
         requestAnimationFrame(() => {
+          applyTheme(theme);
           localStorage.setItem("theme", theme);
           this.pushEvent("theme_changed", { theme: theme });
           // Close the <details> dropdown after selection
@@ -36,6 +52,7 @@ export const ThemeSwitcher = {
     // Sync with server state if changed
     const serverTheme = this.el.dataset.theme;
     if (serverTheme) {
+      applyTheme(serverTheme);
       const themeInputs = this.el.querySelectorAll(".theme-controller-item");
       themeInputs.forEach(input => {
         input.checked = serverTheme === input.value;


### PR DESCRIPTION
## Summary
- The ThemeSwitcher hook saved themes to localStorage but never set `data-theme` on `document.documentElement`, so `@duskmoon-dev/core` CSS theme selectors never activated
- Added `applyTheme()` helper that sets/removes the attribute on mount (restore persisted theme) and on change (activate selected theme)

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] All 3207 tests pass (`mix test`)
- [ ] Manual: select sunshine/moonlight theme → verify CSS variables change immediately
- [ ] Manual: reload page → verify persisted theme is re-applied on mount

Fixes #15