### PR TITLE
fix: make PageHeader sticky nav work without LiveView hooks

### DIFF
--- a/apps/phoenix_duskmoon/assets/js/hooks/page_header.js
+++ b/apps/phoenix_duskmoon/assets/js/hooks/page_header.js
@@ -4,6 +4,10 @@
  */
 export const PageHeader = {
   mounted() {
+    // Skip if the inline script already set up the observer
+    if (this.el._dmPageHeaderObserved) return;
+    this.el._dmPageHeaderObserved = true;
+
     const navId = this.el.dataset.navId;
     const navEl = document.getElementById(navId);
 

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/navigation/page_header.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/navigation/page_header.ex
@@ -272,6 +272,30 @@ defmodule PhoenixDuskmoon.Component.Navigation.PageHeader do
         {render_slot(@inner_block)}
       </div>
     </header>
+    <script>
+    (function() {
+      var header = document.currentScript.previousElementSibling;
+      var navId = header && header.dataset.navId;
+      var nav = navId && document.getElementById(navId);
+      if (!header || !nav) return;
+      if (header._dmPageHeaderObserved) return;
+      header._dmPageHeaderObserved = true;
+      var thresholds = [];
+      for (var i = 0; i <= 10; i++) thresholds.push(i / 10);
+      new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.intersectionRatio <= 0.5) {
+            nav.classList.remove('hidden');
+            nav.setAttribute('aria-hidden', 'false');
+            nav.style.opacity = 1 - entry.intersectionRatio;
+          } else {
+            nav.classList.add('hidden');
+            nav.setAttribute('aria-hidden', 'true');
+          }
+        });
+      }, {root: null, rootMargin: '0px', threshold: thresholds}).observe(header);
+    })();
+    </script>
     """
   end
 end


### PR DESCRIPTION
## Summary
- The `dm_page_header` sticky nav relied on `phx-hook="PageHeader"` which only works in LiveView — on regular controller pages the hook never fired and the nav stayed permanently hidden
- Added an inline `<script>` that sets up `IntersectionObserver` independently, with a `_dmPageHeaderObserved` flag to prevent double-setup when the LiveView hook also fires

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] All 3207 tests pass (`mix test`)
- [x] All 39 page header tests pass
- [ ] Manual: verify sticky nav appears on scroll on a non-LiveView controller page
- [ ] Manual: verify sticky nav still works on LiveView pages

Fixes #16