### PR TITLE
fix: export components css path

### DIFF
--- a/apps/phoenix_duskmoon/package.json
+++ b/apps/phoenix_duskmoon/package.json
@@ -6,6 +6,7 @@
     ".": "./priv/static/phoenix_duskmoon.js",
     "./hooks": "./assets/js/hooks/index.js",
     "./css": "./priv/static/phoenix_duskmoon.css",
+    "./components": "./priv/static/phoenix_duskmoon.css",
     "./svg/mdi/*.svg": "./priv/mdi/svg/*.svg",
     "./svg/bsi/*.svg": "./priv/bsi/svg/*.svg"
   },


### PR DESCRIPTION
## Summary
- export the documented phoenix_duskmoon/components CSS subpath from the npm package
- keep the export pointed at the packaged phoenix_duskmoon.css asset

Fixes #30