### PR TITLE
fix: repair dm_btn confirm dialog

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -136,7 +136,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   def dm_btn(%{confirm: confirm} = assigns) when confirm != "" do
     assigns =
       assigns
-      |> assign_new(:id, fn -> "btn-#{System.unique_integer([:positive])}" end)
+      |> assign(:id, assigns.id || "btn-#{System.unique_integer([:positive])}")
+      |> assign(:confirm_rest, Map.put(assigns.rest, "type", "submit"))
       |> assign(:el_variant, map_variant(assigns.variant))
       |> assign(:el_style, variant_style(assigns.variant))
 
@@ -174,7 +175,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
           {render_slot(@confirm_action)}
         </template>
         <form :if={@confirm_action == []} method="dialog">
-          <el-dm-button variant="primary" class={@confirm_class} {@rest}>
+          <el-dm-button variant="primary" class={@confirm_class} {@confirm_rest}>
             {@confirm_text}
           </el-dm-button>
         </form>

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -150,8 +150,10 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[<el-dm-button]
     assert result =~ ~s[onclick="document.getElementById(&#39;confirm-dialog-]
     assert result =~ ~s[<el-dm-dialog id="confirm-dialog-]
+    refute result =~ ~s[id="confirm-dialog-"]
     assert result =~ ~s[Are you sure?]
     assert result =~ ~s[<el-dm-button variant="primary"]
+    assert result =~ ~s[type="submit"]
     assert result =~ ~s[Yes]
     assert result =~ ~s[<el-dm-button variant="ghost"]
     assert result =~ ~s[Cancel]
@@ -474,6 +476,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
 
     # The phx-click should be on the Yes button inside the dialog
     assert result =~ ~s[phx-click="delete"]
+    assert result =~ ~s[type="submit"]
   end
 
   test "renders button without confirm when confirm is empty string" do


### PR DESCRIPTION
## Summary
- generate a confirm button id when the attr default leaves id nil
- make the confirm Yes button submit the method=dialog form
- cover confirm ids and submit behavior in button component tests

Fixes #27