### PR TITLE
fix: add intrinsic mdi icon dimensions

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/icon/icons.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/icon/icons.ex
@@ -161,6 +161,20 @@ defmodule PhoenixDuskmoon.Component.Icon.Icons do
     """
   )
 
+  attr(:width, :any,
+    default: "1em",
+    doc: """
+    intrinsic SVG width
+    """
+  )
+
+  attr(:height, :any,
+    default: "1em",
+    doc: """
+    intrinsic SVG height
+    """
+  )
+
   attr(:rest, :global, doc: "additional HTML attributes for the SVG element")
 
   def dm_mdi(assigns) do
@@ -176,7 +190,7 @@ defmodule PhoenixDuskmoon.Component.Icon.Icons do
     assigns = assigns |> assign(:inner_svg, inner_svg)
 
     ~H"""
-    <svg xmlns="http://www.w3.org/2000/svg" id={@id} class={@class} fill={@color} viewBox="0 0 24 24" aria-hidden="true" {@rest}>
+    <svg xmlns="http://www.w3.org/2000/svg" id={@id} class={@class} fill={@color} width={@width} height={@height} viewBox="0 0 24 24" aria-hidden="true" {@rest}>
       {raw(@inner_svg)}
     </svg>
     """

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/icon/icons_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/icon/icons_test.exs
@@ -44,6 +44,14 @@ defmodule PhoenixDuskmoon.Component.Icon.IconsTest do
     assert result =~ ~s[<svg xmlns="http://www.w3.org/2000/svg"]
   end
 
+  test "renders Material Design Icon with intrinsic dimensions" do
+    result = render_component(&dm_mdi/1, %{name: "account", class: "w-6 h-6"})
+
+    assert result =~ ~s[width="1em"]
+    assert result =~ ~s[height="1em"]
+    assert result =~ ~s[class="w-6 h-6"]
+  end
+
   test "renders Material Design Icon with custom color" do
     result = render_component(&dm_mdi/1, %{name: "account", color: "#ff0000"})
 


### PR DESCRIPTION
## Summary
- add safe 1em intrinsic width and height defaults to dm_mdi SVG output
- preserve class-based icon sizing overrides
- add focused icon component coverage

Fixes #29