### PR TITLE
fix: add navigation support to dm_btn

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -49,6 +49,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
       <.dm_btn variant="primary" size="lg">Primary Button</.dm_btn>
 
+      <.dm_btn navigate="/dashboard" variant="ghost">Dashboard</.dm_btn>
+
       <.dm_btn confirm="Are you sure?" confirm_title="Confirm Action">Delete</.dm_btn>
 
   """
@@ -88,6 +90,26 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
   attr(:loading, :boolean, default: false, doc: "Show loading state")
   attr(:disabled, :boolean, default: false, doc: "Disable the button")
+
+  attr(:navigate, :string,
+    default: nil,
+    doc: "Navigates from a LiveView to a new LiveView"
+  )
+
+  attr(:patch, :string,
+    default: nil,
+    doc: "Patches the current LiveView"
+  )
+
+  attr(:href, :any,
+    default: nil,
+    doc: "Uses traditional browser navigation to the new location"
+  )
+
+  attr(:replace, :boolean,
+    default: false,
+    doc: "Replace browser history when using navigate or patch"
+  )
 
   # Noise button attributes
   attr(:noise, :boolean, default: false, doc: "Use noise effect button style")
@@ -138,8 +160,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
       assigns
       |> assign(:id, assigns.id || "btn-#{System.unique_integer([:positive])}")
       |> assign(:confirm_rest, Map.put(assigns.rest, "type", "submit"))
-      |> assign(:el_variant, map_variant(assigns.variant))
-      |> assign(:el_style, variant_style(assigns.variant))
+      |> assign_button_element()
 
     ~H"""
     <el-dm-button
@@ -211,12 +232,46 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   end
 
   def dm_btn(%{} = assigns) do
-    assigns =
-      assigns
-      |> assign_new(:id, fn -> nil end)
-      |> assign(:el_variant, map_variant(assigns.variant))
-      |> assign(:el_style, variant_style(assigns.variant))
+    assigns = assign_button_element(assigns)
 
+    ~H"""
+    <.button_link :if={is_binary(@navigate)} navigate={@navigate} replace={@replace}>
+      <.button_element {assigns} />
+    </.button_link>
+    <.button_link :if={!is_binary(@navigate) && is_binary(@patch)} patch={@patch} replace={@replace}>
+      <.button_element {assigns} />
+    </.button_link>
+    <.button_link
+      :if={!is_binary(@navigate) && !is_binary(@patch) && !is_nil(@href) && @href != "#"}
+      href={@href}
+    >
+      <.button_element {assigns} />
+    </.button_link>
+    <.button_element :if={!is_binary(@navigate) && !is_binary(@patch) && (is_nil(@href) || @href == "#")} {assigns} />
+    """
+  end
+
+  defp assign_button_element(assigns) do
+    assigns
+    |> assign_new(:id, fn -> nil end)
+    |> assign(:el_variant, map_variant(assigns.variant))
+    |> assign(:el_style, variant_style(assigns.variant))
+  end
+
+  attr(:id, :any, default: nil)
+  attr(:el_variant, :string, default: nil)
+  attr(:size, :string, default: nil)
+  attr(:shape, :string, default: nil)
+  attr(:loading, :boolean, default: false)
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :any, default: nil)
+  attr(:el_style, :string, default: nil)
+  attr(:rest, :global)
+  slot(:inner_block)
+  slot(:prefix)
+  slot(:suffix)
+
+  defp button_element(assigns) do
     ~H"""
     <el-dm-button
       id={@id}
@@ -236,6 +291,30 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
       {render_slot(@inner_block)}
       <span :for={suffix <- @suffix} slot="suffix">{render_slot(suffix)}</span>
     </el-dm-button>
+    """
+  end
+
+  attr(:navigate, :string, default: nil)
+  attr(:patch, :string, default: nil)
+  attr(:href, :any, default: nil)
+  attr(:replace, :boolean, default: false)
+  slot(:inner_block, required: true)
+
+  defp button_link(%{navigate: to} = assigns) when is_binary(to) do
+    ~H"""
+    <.link navigate={@navigate} replace={@replace}>{render_slot(@inner_block)}</.link>
+    """
+  end
+
+  defp button_link(%{patch: to} = assigns) when is_binary(to) do
+    ~H"""
+    <.link patch={@patch} replace={@replace}>{render_slot(@inner_block)}</.link>
+    """
+  end
+
+  defp button_link(%{href: href} = assigns) when not is_nil(href) and href != "#" do
+    ~H"""
+    <.link href={@href}>{render_slot(@inner_block)}</.link>
     """
   end
 end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -115,6 +115,57 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     refute result =~ "aria-disabled"
   end
 
+  test "renders navigate button as link with button styling" do
+    result =
+      render_component(&dm_btn/1, %{
+        navigate: "/dashboard",
+        variant: "ghost",
+        inner_block: %{inner_block: fn _, _ -> "Dashboard" end}
+      })
+
+    assert result =~ ~s[<a]
+    assert result =~ ~s[href="/dashboard"]
+    assert result =~ ~s[data-phx-link="redirect"]
+    assert result =~ ~s[data-phx-link-state="push"]
+    assert result =~ ~s[<el-dm-button]
+    assert result =~ ~s[variant="ghost"]
+    assert result =~ "Dashboard"
+  end
+
+  test "renders patch button as link with replace state" do
+    result =
+      render_component(&dm_btn/1, %{
+        patch: "/settings?tab=profile",
+        replace: true,
+        variant: "outline",
+        inner_block: %{inner_block: fn _, _ -> "Profile" end}
+      })
+
+    assert result =~ ~s[href="/settings?tab=profile"]
+    assert result =~ ~s[data-phx-link="patch"]
+    assert result =~ ~s[data-phx-link-state="replace"]
+    assert result =~ ~s[variant="outline"]
+  end
+
+  test "renders href button as link with styling attributes" do
+    result =
+      render_component(&dm_btn/1, %{
+        href: "https://example.com",
+        variant: "error",
+        size: "lg",
+        class: "external-action",
+        inner_block: %{inner_block: fn _, _ -> "External" end}
+      })
+
+    assert result =~ ~s[<a]
+    assert result =~ ~s[href="https://example.com"]
+    assert result =~ ~s[variant="primary"]
+    assert result =~ "--color-primary: var(--color-error)"
+    assert result =~ ~s[size="lg"]
+    assert result =~ "external-action"
+    assert result =~ "External"
+  end
+
   test "renders button with noise effect" do
     result =
       render_component(&dm_btn/1, %{


### PR DESCRIPTION
## Summary
- add navigate, patch, href, and replace attrs to dm_btn
- render normal navigation buttons through Phoenix LiveView links while preserving button variants and content
- add scoped component tests for navigate, patch, and href rendering

Fixes #34