### PR TITLE
fix: submit confirm cancel action

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -201,7 +201,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
           </el-dm-button>
         </form>
         <form :if={@show_cancel_action} method="dialog">
-          <el-dm-button variant="ghost" class={@cancel_class}>
+          <el-dm-button variant="ghost" class={@cancel_class} type="submit">
             {@cancel_text}
           </el-dm-button>
         </form>

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -206,7 +206,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[<el-dm-button variant="primary"]
     assert result =~ ~s[type="submit"]
     assert result =~ ~s[Yes]
-    assert result =~ ~s[<el-dm-button variant="ghost"]
+    assert result =~ ~s[<el-dm-button variant="ghost" class="" type="submit"]
     assert result =~ ~s[Cancel]
   end
 


### PR DESCRIPTION
## Summary
- Add type="submit" to the default confirm-dialog Cancel custom element
- Assert the Cancel button can submit its method="dialog" form

Fixes #36