### PR TITLE
fix(bundler): install typography tailwind runtime

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/loader.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/loader.ex
@@ -5,8 +5,10 @@ defmodule DuskmoonBundler.Tailwind.Loader do
   alias DuskmoonBundler.Tailwind.Resolver
 
   @tailwind_install_spec "^4.3.0"
+  @typography_install_spec "^0.5.20"
   @tailwind_runtime_deps %{
-    "tailwindcss" => @tailwind_install_spec
+    "tailwindcss" => @tailwind_install_spec,
+    "@tailwindcss/typography" => @typography_install_spec
   }
 
   def runtime_packages, do: @tailwind_runtime_deps


### PR DESCRIPTION
## Summary
- include @tailwindcss/typography in the isolated Tailwind runtime package set
- fixes CI/Test failures where bundler typography tests cannot resolve the plugin without node_modules

## Verification
- isolated Tailwind runtime check from a cwd without node_modules
- MIX_ENV=test mix test apps/duskmoon_bundler/test/duskmoon_bundler/tailwind_test.exs
- MIX_ENV=test mix test apps/duskmoon_bundler/test
- MIX_ENV=test mix test
- mix format --check-formatted
- mix compile --warnings-as-errors