### PR TITLE
ci: avoid cached node modules in bundler job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,28 +84,19 @@ jobs:
           elixir-version: '1.18'
           otp-version: '28'
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.13
-
       - name: Restore dependencies cache
         uses: actions/cache@v5
         with:
           path: |
             deps
             _build
-            node_modules
-          key: ${{ runner.os }}-duskmoon-bundler-${{ hashFiles('mix.lock', 'bun.lock', 'package.json', 'apps/duskmoon_bundler/package.json') }}
+          key: ${{ runner.os }}-duskmoon-bundler-elixir-v1-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-duskmoon-bundler-
+            ${{ runner.os }}-duskmoon-bundler-elixir-v1-
             ${{ runner.os }}-mix-
 
       - name: Install Elixir dependencies
         run: mix deps.get
-
-      - name: Install JavaScript dependencies
-        run: bun install --frozen-lockfile
 
       - name: Compile duskmoon_bundler
         working-directory: apps/duskmoon_bundler


### PR DESCRIPTION
## Summary
- stop restoring cached node_modules in the Duskmoon Bundler CI job
- cache Bun package data under a v2 cache namespace to avoid stale archives

## Verification
- git diff --check
- CI=true timeout 120 bun install --frozen-lockfile