### PR TITLE
fix: submit forms from dm_btn

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -28,6 +28,23 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     "link" => "ghost"
   }
   @color_override_variants ~w(info success warning error)
+  @submit_onclick [
+                    "if (!this.hasAttribute('disabled')) {",
+                    "const formId = this.getAttribute('form');",
+                    "const form = formId ? document.getElementById(formId) : this.closest('form');",
+                    "if (form) {",
+                    "const submitter = document.createElement('button');",
+                    "submitter.type = 'submit';",
+                    "submitter.hidden = true;",
+                    "if (this.hasAttribute('name')) submitter.name = this.getAttribute('name');",
+                    "if (this.hasAttribute('value')) submitter.value = this.getAttribute('value');",
+                    "form.appendChild(submitter);",
+                    "form.requestSubmit(submitter);",
+                    "submitter.remove();",
+                    "}",
+                    "}"
+                  ]
+                  |> Enum.join(" ")
 
   defp map_variant(nil), do: nil
   defp map_variant(v) when is_map_key(@variant_map, v), do: @variant_map[v]
@@ -252,10 +269,14 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   end
 
   defp assign_button_element(assigns) do
+    submit_onclick = submit_onclick(assigns.rest)
+
     assigns
+    |> assign(:rest, rest_without_onclick(assigns.rest, submit_onclick))
     |> assign_new(:id, fn -> nil end)
     |> assign(:el_variant, map_variant(assigns.variant))
     |> assign(:el_style, variant_style(assigns.variant))
+    |> assign(:submit_onclick, submit_onclick)
   end
 
   attr(:id, :any, default: nil)
@@ -266,6 +287,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   attr(:disabled, :boolean, default: false)
   attr(:class, :any, default: nil)
   attr(:el_style, :string, default: nil)
+  attr(:submit_onclick, :string, default: nil)
   attr(:rest, :global)
   slot(:inner_block)
   slot(:prefix)
@@ -285,6 +307,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
       class={@class}
       style={@el_style}
       phx-hook={if @rest["phx-click"], do: "WebComponentHook"}
+      onclick={@submit_onclick}
       {@rest}
     >
       <span :for={prefix <- @prefix} slot="prefix">{render_slot(prefix)}</span>
@@ -316,5 +339,27 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     ~H"""
     <.link href={@href}>{render_slot(@inner_block)}</.link>
     """
+  end
+
+  # WORKAROUND(upstream): duskmoon-dev/duskmoon-elements#66
+  defp submit_onclick(rest) do
+    if rest_attr(rest, "type") == "submit" do
+      merge_onclick(rest_attr(rest, "onclick"), @submit_onclick)
+    end
+  end
+
+  defp rest_attr(rest, "type"), do: Map.get(rest, "type") || Map.get(rest, :type)
+  defp rest_attr(rest, "onclick"), do: Map.get(rest, "onclick") || Map.get(rest, :onclick)
+
+  defp merge_onclick(nil, submit_onclick), do: submit_onclick
+  defp merge_onclick("", submit_onclick), do: submit_onclick
+  defp merge_onclick(onclick, submit_onclick), do: "#{onclick}; #{submit_onclick}"
+
+  defp rest_without_onclick(rest, nil), do: rest
+
+  defp rest_without_onclick(rest, _submit_onclick) do
+    rest
+    |> Map.delete("onclick")
+    |> Map.delete(:onclick)
   end
 end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -556,6 +556,45 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[value="save"]
   end
 
+  test "renders submit button with native form submit bridge" do
+    result =
+      render_component(&dm_btn/1, %{
+        type: "submit",
+        name: "action",
+        value: "save",
+        form: "note-form",
+        inner_block: %{inner_block: fn _, _ -> "Save" end}
+      })
+
+    assert result =~ "document.createElement"
+    assert result =~ "requestSubmit(submitter)"
+    assert result =~ "submitter.name"
+    assert result =~ "submitter.value"
+    assert result =~ "getAttribute(&#39;form&#39;)"
+  end
+
+  test "does not render submit bridge for non-submit buttons" do
+    result =
+      render_component(&dm_btn/1, %{
+        type: "button",
+        inner_block: %{inner_block: fn _, _ -> "Cancel" end}
+      })
+
+    refute result =~ "requestSubmit"
+  end
+
+  test "merges custom onclick with submit bridge" do
+    result =
+      render_component(&dm_btn/1, %{
+        type: "submit",
+        onclick: "window.beforeSubmit()",
+        inner_block: %{inner_block: fn _, _ -> "Save" end}
+      })
+
+    assert result =~ "window.beforeSubmit()"
+    assert result =~ "requestSubmit(submitter)"
+  end
+
   test "renders confirm dialog with empty confirm_action shows default Yes button" do
     result =
       render_component(&dm_btn/1, %{


### PR DESCRIPTION
## Summary
- Add a submit bridge for `dm_btn type="submit"` so browser clicks submit the associated form
- Preserve submitter `name` and `value` through a temporary native submitter
- Add button component tests for submit bridging and non-submit behavior

Upstream dependency request: duskmoon-dev/duskmoon-elements#66

Fixes #39