### PR TITLE
fix: render field errors in form inputs

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/form.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/form.ex
@@ -132,6 +132,26 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Form do
     """
   end
 
+  @doc false
+  def field_errors(%Phoenix.HTML.FormField{errors: errors}, explicit_errors)
+      when explicit_errors in [nil, []] do
+    errors
+    |> List.wrap()
+    |> Enum.map(&translate_error/1)
+  end
+
+  def field_errors(_field, explicit_errors), do: List.wrap(explicit_errors)
+
+  defp translate_error({message, opts}) when is_binary(message) and is_list(opts) do
+    Enum.reduce(opts, message, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
+    end)
+  end
+
+  defp translate_error({message, _opts}), do: to_string(message)
+  defp translate_error(message) when is_binary(message), do: message
+  defp translate_error(message), do: to_string(message)
+
   @doc """
   Generates an alert component.
 

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
@@ -234,7 +234,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Input do
   def dm_input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
-    # |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(:errors, field_errors(field, assigns[:errors]))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> dm_input()

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/textarea.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/textarea.ex
@@ -13,7 +13,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Textarea do
   """
   use Phoenix.Component
 
-  import PhoenixDuskmoon.Component.DataEntry.Form, only: [dm_error: 1]
+  import PhoenixDuskmoon.Component.DataEntry.Form, only: [dm_error: 1, field_errors: 2]
   import PhoenixDuskmoon.Component.Helpers, only: [css_color: 1]
 
   @doc """
@@ -82,6 +82,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Textarea do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
     |> assign_new(:name, fn -> field.name end)
+    |> assign(:errors, field_errors(field, assigns[:errors]))
     |> assign(:value, field.value)
     |> dm_textarea()
   end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
@@ -2472,6 +2472,62 @@ defmodule PhoenixDuskmoon.Component.DataEntry.InputTest do
 
       assert result =~ ~s(name="post[tags][]")
     end
+
+    test "renders errors from FormField" do
+      field =
+        Phoenix.Component.to_form(%{"title" => ""},
+          as: "post",
+          errors: [title: {"can't be blank", []}]
+        )[:title]
+
+      result =
+        render_component(&dm_input/1, %{
+          field: field,
+          type: "text",
+          label: "Title"
+        })
+
+      assert result =~ "can&#39;t be blank"
+      assert result =~ "form-group-error"
+      assert result =~ ~s[aria-invalid="true"]
+      assert result =~ ~s[aria-describedby="post_title-errors"]
+    end
+
+    test "interpolates FormField error options" do
+      field =
+        Phoenix.Component.to_form(%{"title" => ""},
+          as: "post",
+          errors: [title: {"should be at least %{count} character(s)", [count: 3]}]
+        )[:title]
+
+      result =
+        render_component(&dm_input/1, %{
+          field: field,
+          type: "text",
+          label: "Title"
+        })
+
+      assert result =~ "should be at least 3 character(s)"
+    end
+
+    test "explicit errors override FormField errors" do
+      field =
+        Phoenix.Component.to_form(%{"title" => ""},
+          as: "post",
+          errors: [title: {"can't be blank", []}]
+        )[:title]
+
+      result =
+        render_component(&dm_input/1, %{
+          field: field,
+          type: "text",
+          label: "Title",
+          errors: ["custom error"]
+        })
+
+      assert result =~ "custom error"
+      refute result =~ "can&#39;t be blank"
+    end
   end
 
   describe "rating edge cases" do

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/textarea_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/textarea_test.exs
@@ -289,6 +289,34 @@ defmodule PhoenixDuskmoon.Component.DataEntry.TextareaTest do
       assert result =~ ~s[rows="10"]
       assert result =~ "textarea-resize-none"
     end
+
+    test "renders errors from FormField" do
+      field =
+        Phoenix.Component.to_form(%{"bio" => ""},
+          as: "user",
+          errors: [bio: {"can't be blank", []}]
+        )[:bio]
+
+      result = render_component(&dm_textarea/1, %{field: field, label: "Bio"})
+
+      assert result =~ "can&#39;t be blank"
+      assert result =~ "form-group-error"
+      assert result =~ ~s[aria-invalid="true"]
+      assert result =~ ~s[aria-describedby="user_bio-errors"]
+    end
+
+    test "explicit errors override FormField errors" do
+      field =
+        Phoenix.Component.to_form(%{"bio" => ""},
+          as: "user",
+          errors: [bio: {"can't be blank", []}]
+        )[:bio]
+
+      result = render_component(&dm_textarea/1, %{field: field, errors: ["custom error"]})
+
+      assert result =~ "custom error"
+      refute result =~ "can&#39;t be blank"
+    end
   end
 
   test "renders textarea with aria-invalid and error messages when errors present" do


### PR DESCRIPTION
## Summary
- Add shared FormField error formatting with option interpolation
- Render FormField errors by default in `dm_input` and `dm_textarea` field usage
- Cover field-derived errors and explicit override behavior in component tests

Fixes #40