### PR TITLE
fix: allow chat input quick actions

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/chat.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/chat.ex
@@ -132,7 +132,8 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chat do
   attr(:class, :any, default: nil, doc: "additional CSS classes")
 
   attr(:rest, :global,
-    include: ~w[duskmoon-send-send duskmoon-receive duskmoon-receive-reset],
+    include:
+      ~w[duskmoon-send-send duskmoon-send-quick-action duskmoon-receive duskmoon-receive-reset],
     doc: "additional HTML attributes"
   )
 

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/chat_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/chat_test.exs
@@ -104,6 +104,16 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.ChatTest do
     assert result =~ ~s[phx-hook="WebComponentHook"]
   end
 
+  test "renders chat input quick action event bridge" do
+    result =
+      render_component(&dm_chat_input/1, %{
+        "duskmoon-send-quick-action": "steer_message"
+      })
+
+    assert result =~ ~s[duskmoon-send-quick-action="steer_message"]
+    assert result =~ ~s[phx-hook="WebComponentHook"]
+  end
+
   test "renders chat input from form field" do
     field = Phoenix.Component.to_form(%{"message" => "Hello"}, as: "chat")[:message]
     result = render_component(&dm_chat_input/1, %{field: field})


### PR DESCRIPTION
## Summary
- Add `duskmoon-send-quick-action` to the `dm_chat_input` global attr allowlist
- Cover quick-action event bridge rendering in chat component tests

Fixes #41