### PR TITLE
fix(native): include rustler for source builds

### DIFF
--- a/apps/duskmoon_bundler/mix.exs
+++ b/apps/duskmoon_bundler/mix.exs
@@ -42,6 +42,7 @@ defmodule DuskmoonBundler.MixProject do
       {:duskmoon_vize, in_umbrella: true},
       {:duskmoon_oxide, in_umbrella: true},
       {:duskmoon_quickbeam, in_umbrella: true},
+      {:rustler, "~> 0.36 or ~> 0.37 or ~> 0.38", optional: true},
       {:dotenvy, "~> 1.1"},
       {:floki, "~> 0.38"},
       {:plug, "~> 1.16"},

--- a/apps/duskmoon_quickbeam/mix.exs
+++ b/apps/duskmoon_quickbeam/mix.exs
@@ -76,6 +76,7 @@ defmodule QuickBEAM.MixProject do
       {:ex_slop, "~> 0.2", only: [:dev, :test], runtime: false},
       {:jason, "~> 1.4"},
       {:duskmoon_oxc, in_umbrella: true},
+      {:rustler, "~> 0.36 or ~> 0.37 or ~> 0.38", optional: true},
       {:duskmoon_npm, in_umbrella: true},
       {:mint_web_socket, "~> 1.0"},
       {:nimble_pool, "~> 1.1"},


### PR DESCRIPTION
## Summary
- add rustler as a direct optional dependency for duskmoon_bundler
- add rustler as a direct optional dependency for duskmoon_quickbeam

## Verification
- mix deps.get
- mix format
- mix format --check-formatted
- DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix compile --warnings-as-errors (apps/duskmoon_oxc)
- DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix compile --warnings-as-errors (apps/duskmoon_quickbeam) progressed past duskmoon_oxc source build; local run then stopped at missing local Zig, which CI installs separately
