### PR TITLE
fix: allow zigler 0.16 in quickbeam

### DIFF
--- a/apps/duskmoon_quickbeam/mix.exs
+++ b/apps/duskmoon_quickbeam/mix.exs
@@ -69,7 +69,7 @@ defmodule QuickBEAM.MixProject do
   defp deps do
     [
       {:zigler_precompiled, "~> 0.1.4"},
-      {:zigler, "~> 0.13.0 or ~> 0.14.0 or ~> 0.15.0"},
+      {:zigler, "~> 0.13.0 or ~> 0.14.0 or ~> 0.15.0 or ~> 0.16.0"},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:ex_dna, "~> 1.1", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
## Summary
- widen duskmoon_quickbeam Zigler requirement to include 0.16
- verify QuickBEAM still compiles with warnings treated as errors

Fixes #54