### PR TITLE
fix: restrict flash dismissal to close button

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/flash.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/flash.ex
@@ -37,10 +37,6 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Flash do
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
       phx-mounted={@autoshow && JS.add_class("toast-open", to: "##{@id}")}
-      phx-click={
-        JS.push("lv:clear-flash", value: %{key: @kind})
-        |> JS.remove_class("toast-open", to: "##{@id}")
-      }
       role="alert"
       aria-live={if(@kind == :error, do: "assertive", else: "polite")}
       aria-atomic="true"
@@ -60,6 +56,10 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Flash do
         type="button"
         class="toast-close"
         aria-label={@close_label}
+        phx-click={
+          JS.push("lv:clear-flash", value: %{key: @kind})
+          |> JS.remove_class("toast-open", to: "##{@id}")
+        }
       >
         <.dm_mdi name="close" class="w-4 h-4" />
       </button>

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_test.exs
@@ -160,6 +160,17 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.FlashTest do
       assert result =~ "toast-close"
     end
 
+    test "only close button clears the flash" do
+      result =
+        render_component(&dm_flash/1, %{
+          kind: :info,
+          flash: %{"info" => "Closeable"}
+        })
+
+      assert result =~ ~r/<div id="flash"(?:(?!phx-click).)*role="alert"/s
+      assert result =~ ~r/<button[^>]*class="toast-close"[^>]*phx-click="[^"]*lv:clear-flash/s
+    end
+
     test "renders flash without close button when close=false" do
       result =
         render_component(&dm_flash/1, %{


### PR DESCRIPTION
## Summary
- move flash clear-click behavior from the toast container to the close button
- add regression coverage that body clicks do not carry the clear-flash handler

Fixes #55