### PR TITLE
fix: align bundler elixir requirement

### DIFF
--- a/apps/duskmoon_bundler/mix.exs
+++ b/apps/duskmoon_bundler/mix.exs
@@ -8,7 +8,7 @@ defmodule DuskmoonBundler.MixProject do
     [
       app: :duskmoon_bundler,
       version: @version,
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Summary
- align duskmoon_bundler Elixir requirement with its in-repo dependency graph
- keep compatibility at Elixir 1.18 instead of advertising 1.17 support

Fixes #50
Fixes #51