### PR TITLE
fix: clear duskmoon compile warnings

### DIFF
--- a/apps/duskmoon_hex_solver/lib/hex_solver/incompatibility.ex
+++ b/apps/duskmoon_hex_solver/lib/hex_solver/incompatibility.ex
@@ -116,18 +116,18 @@ defmodule HexSolver.Incompatibility do
   end
 
   def to_string(%Incompatibility{terms: [%Term{positive: false} = term]}, opts) do
-    "#{terse_name(%Term{term | positive: true}, opts)} is required"
+    "#{terse_name(term_abs(term), opts)} is required"
   end
 
   def to_string(
-        %Incompatibility{terms: [%{positive: true} = left, %{positive: true} = right]},
+        %Incompatibility{terms: [%Term{positive: true} = left, %Term{positive: true} = right]},
         opts
       ) do
     "#{terse_name(left, opts)} is incompatible with #{terse_name(right, opts)}"
   end
 
   def to_string(
-        %Incompatibility{terms: [%{positive: false} = left, %{positive: false} = right]},
+        %Incompatibility{terms: [%Term{positive: false} = left, %Term{positive: false} = right]},
         opts
       ) do
     "either #{bright_term_abs(left, opts)} or #{bright_term_abs(right, opts)}"

--- a/apps/duskmoon_hex_solver/lib/hex_solver/solver.ex
+++ b/apps/duskmoon_hex_solver/lib/hex_solver/solver.ex
@@ -93,9 +93,9 @@ defmodule HexSolver.Solver do
     {:error, :conflict}
   end
 
-  defp propagate_incompatibility([], unsatisfied, incompatibility, state, _opts) do
+  defp propagate_incompatibility([], %Term{} = unsatisfied, incompatibility, state, _opts) do
     # Only one term in the incompatibility was unsatisfied
-    unsatisfied = %{unsatisfied | positive: not unsatisfied.positive}
+    unsatisfied = %Term{unsatisfied | positive: not unsatisfied.positive}
     debug(state, fn -> "RESOLVER: derived #{unsatisfied}" end)
 
     solution = PartialSolution.derive(state.solution, unsatisfied, incompatibility)
@@ -109,14 +109,14 @@ defmodule HexSolver.Solver do
       :done
     else
       case PackageLister.pick_package(state.lister, unsatisfied) do
-        {:ok, package_range, nil} ->
+        {:ok, %PackageRange{} = package_range, nil} ->
           # If no version satisfies the constraint then add an incompatibility that indicates that
           term = %Term{positive: true, package_range: package_range}
           incompatibility = Incompatibility.new([term], :no_versions)
           state = add_incompatibility(state, incompatibility)
           {:choice, package_range.name, state}
 
-        {:ok, package_range, version} ->
+        {:ok, %PackageRange{} = package_range, version} ->
           {lister, incompatibilities} =
             PackageLister.dependencies_as_incompatibilities(
               state.lister,
@@ -153,7 +153,7 @@ defmodule HexSolver.Solver do
           state = %{state | solution: solution}
           {:choice, package_range.name, state}
 
-        {:error, package_range} ->
+        {:error, %PackageRange{} = package_range} ->
           package_range = %PackageRange{package_range | constraint: Util.any()}
           term = %Term{positive: true, package_range: package_range}
           incompatibility = Incompatibility.new([term], :package_not_found)

--- a/apps/duskmoon_hex_solver/lib/hex_solver/term.ex
+++ b/apps/duskmoon_hex_solver/lib/hex_solver/term.ex
@@ -4,8 +4,6 @@ defmodule HexSolver.Term do
   alias HexSolver.{Constraint, PackageRange, Term}
   alias HexSolver.Constraints.Empty
 
-  require Logger
-
   defstruct positive: true,
             package_range: nil,
             optional: false

--- a/apps/duskmoon_npm/lib/npm/dependency/outdated.ex
+++ b/apps/duskmoon_npm/lib/npm/dependency/outdated.ex
@@ -55,7 +55,6 @@ defmodule NPM.Dependency.Outdated do
     case NPM.SemverUtil.update_type(current, latest) do
       :none -> :current
       type when type in [:major, :minor, :patch] -> type
-      _ -> :current
     end
   end
 

--- a/apps/duskmoon_npm/lib/npm/resolver.ex
+++ b/apps/duskmoon_npm/lib/npm/resolver.ex
@@ -296,8 +296,6 @@ defmodule NPM.Resolver do
     end)
   end
 
-  defp find_dependents(_name, _packument, _package, acc), do: acc
-
   defp version_dependencies(%{dependencies: deps}) when is_map(deps), do: deps
   defp version_dependencies(%{"dependencies" => deps}) when is_map(deps), do: deps
   defp version_dependencies(_info), do: %{}


### PR DESCRIPTION
## Summary
- remove unused and unreachable code that emitted warnings
- tighten hex solver struct patterns to avoid struct update warnings
- keep behavior unchanged while satisfying warnings-as-errors builds

Fixes #53