### PR TITLE
fix: make bundler npm runtime resolution timeout configurable

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
@@ -22,6 +22,7 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
     lockfile_path = Path.join(install_dir, "npm.lock")
     metadata_path = Path.join(install_dir, "duskmoon-bundler-runtime.json")
     signature = install_signature(packages)
+    resolver_opts = resolver_opts(opts)
 
     with_lock(install_dir, fn ->
       if Keyword.get(opts, :force, false) or metadata_mismatch?(metadata_path, signature) do
@@ -30,7 +31,7 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
 
       unless install_intact?(lockfile_path, node_modules, metadata_path, signature) do
         File.mkdir_p!(install_dir)
-        resolve_and_link!(packages, node_modules, lockfile_path)
+        resolve_and_link!(packages, node_modules, lockfile_path, resolver_opts)
         write_metadata!(metadata_path, signature, packages)
       end
     end)
@@ -38,10 +39,10 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
     %{install_dir: install_dir, node_modules: node_modules}
   end
 
-  defp resolve_and_link!(packages, node_modules, lockfile_path) do
+  defp resolve_and_link!(packages, node_modules, lockfile_path, resolver_opts) do
     NPM.Resolver.clear_cache()
 
-    case NPM.Resolver.resolve(packages) do
+    case NPM.Resolver.resolve(packages, resolver_opts) do
       {:ok, resolved} ->
         {_nested, flat} = Map.pop(resolved, :nested, %{})
         lockfile = build_lockfile(flat)
@@ -51,6 +52,16 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
 
       {:error, message} ->
         raise "NPM package resolution failed:\n#{message}"
+    end
+  end
+
+  defp resolver_opts(opts) do
+    resolver_opts = Keyword.get(opts, :resolver_opts, [])
+
+    if Keyword.has_key?(opts, :prefetch_timeout) do
+      Keyword.put(resolver_opts, :prefetch_timeout, Keyword.fetch!(opts, :prefetch_timeout))
+    else
+      resolver_opts
     end
   end
 

--- a/apps/duskmoon_npm/lib/npm/config.ex
+++ b/apps/duskmoon_npm/lib/npm/config.ex
@@ -32,6 +32,13 @@ defmodule NPM.Config do
       read_npmrc_auth_token(registry_url)
   end
 
+  @doc "Read the async resolver prefetch timeout in milliseconds."
+  @spec prefetch_timeout :: non_neg_integer()
+  def prefetch_timeout do
+    env_integer("NPM_EX_PREFETCH_TIMEOUT_MS") ||
+      Application.get_env(:duskmoon_npm, :prefetch_timeout, 30_000)
+  end
+
   @doc "Read the global package cache directory."
   @spec cache_dir :: String.t()
   def cache_dir do

--- a/apps/duskmoon_npm/lib/npm/resolver.ex
+++ b/apps/duskmoon_npm/lib/npm/resolver.ex
@@ -26,7 +26,6 @@ defmodule NPM.Resolver do
   @max_nesting_depth 128
   @max_prefetch_depth 10
   @prefetch_concurrency 16
-  @fetch_timeout 30_000
 
   @doc """
   Resolve a set of root dependencies to exact versions.
@@ -48,10 +47,22 @@ defmodule NPM.Resolver do
     ensure_cache()
     overrides = Keyword.get(opts, :overrides, %{})
     if overrides != %{}, do: store_overrides(overrides)
-    resolve_with_nesting(root_deps, MapSet.new(), %{}, 0)
+    store_resolver_opts(opts)
+    resolve_with_nesting(root_deps, MapSet.new(), %{}, 0, opts)
   rescue
     error in [ExoticDeps.Error, PrefetchError, RegistryPolicy.Error] ->
       {:error, Exception.message(error)}
+  end
+
+  defp store_resolver_opts(opts) do
+    :ets.insert(@table, {:__resolver_opts__, Keyword.take(opts, [:prefetch_timeout])})
+  end
+
+  defp get_resolver_opts do
+    case :ets.lookup(@table, :__resolver_opts__) do
+      [{_, opts}] -> opts
+      [] -> []
+    end
   end
 
   defp store_overrides(overrides) do
@@ -65,13 +76,18 @@ defmodule NPM.Resolver do
     end
   end
 
-  defp resolve_with_nesting(_root_deps, _excluded, _nested, depth)
+  @doc false
+  def prefetch_timeout(opts \\ []) do
+    Keyword.get(opts, :prefetch_timeout) || NPM.Config.prefetch_timeout()
+  end
+
+  defp resolve_with_nesting(_root_deps, _excluded, _nested, depth, _opts)
        when depth > @max_nesting_depth do
     {:error, "Too many resolution retries — deeply conflicting dependencies"}
   end
 
-  defp resolve_with_nesting(root_deps, excluded, nested, depth) do
-    case prefetch_tree(Map.keys(root_deps)) do
+  defp resolve_with_nesting(root_deps, excluded, nested, depth, opts) do
+    case prefetch_tree(Map.keys(root_deps), opts) do
       :ok ->
         dependencies = build_dependencies(root_deps)
 
@@ -90,7 +106,7 @@ defmodule NPM.Resolver do
               new_nested = collect_nested_versions(conflict_packages)
               merged_nested = Map.merge(nested, new_nested)
               new_excluded = Enum.reduce(conflict_packages, excluded, &MapSet.put(&2, &1))
-              resolve_with_nesting(root_deps, new_excluded, merged_nested, depth + 1)
+              resolve_with_nesting(root_deps, new_excluded, merged_nested, depth + 1, opts)
             else
               {:error, message}
             end
@@ -332,7 +348,7 @@ defmodule NPM.Resolver do
     packages
     |> Enum.map(fn {_repo, name} -> name end)
     |> Enum.reject(&cached?/1)
-    |> prefetch_packages()
+    |> prefetch_packages(get_resolver_opts())
     |> case do
       :ok -> :ok
       {:error, reason} -> raise PrefetchError, reason: reason
@@ -535,13 +551,13 @@ defmodule NPM.Resolver do
     end
   end
 
-  defp prefetch_packages([]), do: :ok
+  defp prefetch_packages([], _opts), do: :ok
 
-  defp prefetch_packages(packages) do
+  defp prefetch_packages(packages, opts) do
     packages
     |> Task.async_stream(&safe_fetch_and_cache/1,
       max_concurrency: @prefetch_concurrency,
-      timeout: @fetch_timeout,
+      timeout: prefetch_timeout(opts),
       ordered: false,
       on_timeout: :kill_task
     )
@@ -556,13 +572,13 @@ defmodule NPM.Resolver do
     kind, reason -> {:error, {kind, reason}}
   end
 
-  defp prefetch_tree(packages, depth \\ 0)
-  defp prefetch_tree(_packages, depth) when depth > @max_prefetch_depth, do: :ok
+  defp prefetch_tree(packages, opts), do: prefetch_tree(packages, 0, opts)
+  defp prefetch_tree(_packages, depth, _opts) when depth > @max_prefetch_depth, do: :ok
 
-  defp prefetch_tree(packages, depth) do
+  defp prefetch_tree(packages, depth, opts) do
     to_fetch = Enum.reject(packages, &cached?/1)
 
-    case prefetch_packages(to_fetch) do
+    case prefetch_packages(to_fetch, opts) do
       :ok ->
         next_level =
           to_fetch
@@ -571,7 +587,7 @@ defmodule NPM.Resolver do
           |> Enum.reject(&cached?/1)
 
         if next_level != [] do
-          prefetch_tree(next_level, depth + 1)
+          prefetch_tree(next_level, depth + 1, opts)
         else
           :ok
         end

--- a/apps/duskmoon_npm/test/npm/config_test.exs
+++ b/apps/duskmoon_npm/test/npm/config_test.exs
@@ -5,7 +5,9 @@ defmodule NPM.ConfigTest do
     old_cwd = File.cwd!()
     old_home = System.get_env("HOME")
     old_npm_token = System.get_env("NPM_TOKEN")
+    old_prefetch_timeout = System.get_env("NPM_EX_PREFETCH_TIMEOUT_MS")
     old_app_token = Application.get_env(:duskmoon_npm, :token)
+    old_app_prefetch_timeout = Application.get_env(:duskmoon_npm, :prefetch_timeout)
 
     tmp_dir =
       Path.join(System.tmp_dir!(), "npm_config_test_#{System.unique_integer([:positive])}")
@@ -19,14 +21,18 @@ defmodule NPM.ConfigTest do
 
     System.put_env("HOME", home_dir)
     System.delete_env("NPM_TOKEN")
+    System.delete_env("NPM_EX_PREFETCH_TIMEOUT_MS")
     Application.delete_env(:duskmoon_npm, :token)
+    Application.delete_env(:duskmoon_npm, :prefetch_timeout)
     File.cd!(project_dir)
 
     on_exit(fn ->
       File.cd!(old_cwd)
       restore_env("HOME", old_home)
       restore_env("NPM_TOKEN", old_npm_token)
+      restore_env("NPM_EX_PREFETCH_TIMEOUT_MS", old_prefetch_timeout)
       restore_app_env(:token, old_app_token)
+      restore_app_env(:prefetch_timeout, old_app_prefetch_timeout)
       File.rm_rf!(tmp_dir)
     end)
 
@@ -50,6 +56,19 @@ defmodule NPM.ConfigTest do
     """)
 
     assert NPM.Config.auth_token("https://nexus.gsmlg.net/repository/npm") == "nexus-token"
+  end
+
+  test "reads resolver prefetch timeout from app config" do
+    Application.put_env(:duskmoon_npm, :prefetch_timeout, 120_000)
+
+    assert NPM.Config.prefetch_timeout() == 120_000
+  end
+
+  test "prefers resolver prefetch timeout from environment" do
+    Application.put_env(:duskmoon_npm, :prefetch_timeout, 120_000)
+    System.put_env("NPM_EX_PREFETCH_TIMEOUT_MS", "180000")
+
+    assert NPM.Config.prefetch_timeout() == 180_000
   end
 
   defp restore_env(name, nil), do: System.delete_env(name)

--- a/apps/duskmoon_npm/test/npm_test.exs
+++ b/apps/duskmoon_npm/test/npm_test.exs
@@ -31,6 +31,22 @@ defmodule NPMTest do
              "untrusted npm registry URL https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz. Allowed registry origins: https://npm.gsmlg.dev."
   end
 
+  test "resolver prefetch timeout can be configured per call" do
+    original_timeout = Application.get_env(:duskmoon_npm, :prefetch_timeout)
+
+    Application.put_env(:duskmoon_npm, :prefetch_timeout, 45_000)
+
+    try do
+      assert NPM.Resolver.prefetch_timeout([]) == 45_000
+      assert NPM.Resolver.prefetch_timeout(prefetch_timeout: 120_000) == 120_000
+    after
+      case original_timeout do
+        nil -> Application.delete_env(:duskmoon_npm, :prefetch_timeout)
+        value -> Application.put_env(:duskmoon_npm, :prefetch_timeout, value)
+      end
+    end
+  end
+
   test "bundled npm semver parser supports npm ranges" do
     assert NPMSemver.matches?("1.2.3", "^1.0.0")
     refute NPMSemver.matches?("2.0.0", "^1.0.0")


### PR DESCRIPTION
## Summary
- add configurable npm resolver prefetch timeout via app config, env, and resolver options
- propagate resolver timeout options through bundler runtime installs
- cover timeout config and per-call resolver behavior in NPM tests

Fixes #48