### PR TITLE
fix: sync native package checksums

### DIFF
--- a/.github/scripts/verify_native_checksums.exs
+++ b/.github/scripts/verify_native_checksums.exs
@@ -1,0 +1,70 @@
+defmodule VerifyNativeChecksums do
+  @moduledoc false
+
+  def main([tag | checksum_files]) when checksum_files != [] do
+    asset_digests = release_asset_digests!(tag)
+
+    checksum_files
+    |> Enum.flat_map(&mismatches(&1, asset_digests))
+    |> report!()
+  end
+
+  def main(_args) do
+    IO.puts(
+      :stderr,
+      "usage: elixir verify_native_checksums.exs <release-tag> <checksum-file> [...]"
+    )
+
+    System.halt(2)
+  end
+
+  defp release_asset_digests!(tag) do
+    case System.cmd("gh", ["release", "view", tag, "--json", "assets"], stderr_to_stdout: true) do
+      {json, 0} ->
+        json
+        |> JSON.decode!()
+        |> Map.fetch!("assets")
+        |> Map.new(fn %{"name" => name, "digest" => digest} -> {name, digest} end)
+
+      {output, status} ->
+        IO.puts(:stderr, "failed to read GitHub release #{tag} assets (exit #{status})")
+        IO.puts(:stderr, output)
+        System.halt(status)
+    end
+  end
+
+  defp mismatches(checksum_file, asset_digests) do
+    {checksums, _binding} = Code.eval_file(checksum_file)
+
+    Enum.flat_map(checksums, fn {name, expected_digest} ->
+      case Map.fetch(asset_digests, name) do
+        {:ok, ^expected_digest} ->
+          []
+
+        {:ok, actual_digest} ->
+          [
+            """
+            #{checksum_file}: #{name}
+              expected #{expected_digest}
+              release  #{actual_digest}
+            """
+          ]
+
+        :error ->
+          ["#{checksum_file}: #{name}\n  missing from GitHub release assets\n"]
+      end
+    end)
+  end
+
+  defp report!([]) do
+    IO.puts("Native checksum files match GitHub release assets")
+  end
+
+  defp report!(mismatches) do
+    IO.puts(:stderr, "Native checksum files do not match GitHub release assets:")
+    Enum.each(mismatches, &IO.puts(:stderr, &1))
+    System.halt(1)
+  end
+end
+
+VerifyNativeChecksums.main(System.argv())

--- a/.github/workflows/native-prebuild.yml
+++ b/.github/workflows/native-prebuild.yml
@@ -11,6 +11,11 @@ on:
         description: 'Git revision to build from'
         required: true
         type: string
+      allow-existing-release-overwrite:
+        description: 'Allow overwriting assets on an already-published release'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
@@ -22,6 +27,11 @@ on:
         required: true
         default: 'main'
         type: string
+      allow-existing-release-overwrite:
+        description: 'Allow overwriting assets on an already-published release'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -31,8 +41,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-upload-guard:
+    name: Check release upload safety
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse published release overwrite
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          ALLOW_OVERWRITE: ${{ inputs.allow-existing-release-overwrite }}
+        run: |
+          set -euo pipefail
+
+          if [ "${ALLOW_OVERWRITE}" = "true" ]; then
+            echo "Existing release overwrite explicitly allowed for v${VERSION}"
+            exit 0
+          fi
+
+          is_draft="$(gh release view "v${VERSION}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [ "${is_draft}" = "false" ]; then
+            echo "Refusing to overwrite native assets on published release v${VERSION}" >&2
+            echo "Run the full release workflow if native Hex packages also need checksum replacement." >&2
+            exit 1
+          fi
+
   rust-nifs:
     name: ${{ matrix.crate.app }} / ${{ matrix.crate.name }} / ${{ matrix.target.target }}
+    needs: release-upload-guard
     runs-on: ${{ matrix.target.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       git-ref: ${{ inputs.git-ref }}
+      allow-existing-release-overwrite: true
     secrets: inherit
 
   publish:
@@ -169,6 +170,18 @@ jobs:
             DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix compile --force
             mix zigler_precompiled.download QuickBEAM.Native --all --print
           )
+
+      - name: Verify native checksum files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          elixir .github/scripts/verify_native_checksums.exs "v${{ inputs.version }}" \
+            apps/duskmoon_oxc/checksum-Elixir.OXC.Native.exs \
+            apps/duskmoon_oxc/checksum-Elixir.OXC.Format.Native.exs \
+            apps/duskmoon_oxc/checksum-Elixir.OXC.Lint.Native.exs \
+            apps/duskmoon_oxide/checksum-Elixir.Oxide.Native.exs \
+            apps/duskmoon_vize/checksum-Elixir.Vize.Native.exs \
+            apps/duskmoon_quickbeam/checksum-QuickBEAM.Native.exs
 
       - name: Prepare package assets
         run: mix prepublish
@@ -264,10 +277,11 @@ jobs:
           MIX_ENV: prod
         run: |
           if mix hex.info duskmoon_oxc "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "duskmoon_oxc ${{ inputs.version }} is already published; skipping"
+            echo "duskmoon_oxc ${{ inputs.version }} is already published; replacing to sync native checksums"
           else
-            mix hex.publish package --yes --replace
+            echo "Publishing duskmoon_oxc ${{ inputs.version }}"
           fi
+          mix hex.publish package --yes --replace
 
       - name: Fetch duskmoon_vize Hex dependencies
         working-directory: apps/duskmoon_vize
@@ -280,10 +294,11 @@ jobs:
           MIX_ENV: prod
         run: |
           if mix hex.info duskmoon_vize "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "duskmoon_vize ${{ inputs.version }} is already published; skipping"
+            echo "duskmoon_vize ${{ inputs.version }} is already published; replacing to sync native checksums"
           else
-            mix hex.publish package --yes --replace
+            echo "Publishing duskmoon_vize ${{ inputs.version }}"
           fi
+          mix hex.publish package --yes --replace
 
       - name: Fetch duskmoon_oxide Hex dependencies
         working-directory: apps/duskmoon_oxide
@@ -296,10 +311,11 @@ jobs:
           MIX_ENV: prod
         run: |
           if mix hex.info duskmoon_oxide "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "duskmoon_oxide ${{ inputs.version }} is already published; skipping"
+            echo "duskmoon_oxide ${{ inputs.version }} is already published; replacing to sync native checksums"
           else
-            mix hex.publish package --yes --replace
+            echo "Publishing duskmoon_oxide ${{ inputs.version }}"
           fi
+          mix hex.publish package --yes --replace
 
       - name: Fetch duskmoon_quickbeam Hex dependencies
         working-directory: apps/duskmoon_quickbeam
@@ -312,10 +328,11 @@ jobs:
           MIX_ENV: prod
         run: |
           if mix hex.info duskmoon_quickbeam "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "duskmoon_quickbeam ${{ inputs.version }} is already published; skipping"
+            echo "duskmoon_quickbeam ${{ inputs.version }} is already published; replacing to sync native checksums"
           else
-            mix hex.publish package --yes --replace
+            echo "Publishing duskmoon_quickbeam ${{ inputs.version }}"
           fi
+          mix hex.publish package --yes --replace
 
       - name: Fetch duskmoon_bundler Hex dependencies
         working-directory: apps/duskmoon_bundler


### PR DESCRIPTION
## Summary
- add a release checksum verifier that compares generated native checksum files to GitHub release asset digests
- replace existing Hex packages for native artifacts after checksum generation so rerunning the release workflow can repair stale checksums
- block standalone native prebuild runs from overwriting assets on an already-published release unless explicitly allowed

## Verification
- reproduced the published `duskmoon_oxc` 9.6.2 checksum failure via `mix deps.compile duskmoon_oxc --force`
- verified published 9.6.2 checksums are stale for `duskmoon_oxc`, `duskmoon_oxide`, `duskmoon_vize`, and `duskmoon_quickbeam` against current GitHub release assets
- `elixir .github/scripts/verify_native_checksums.exs v9.6.2 <matching checksum file>`
- `git diff --check`
- `yq . .github/workflows/release.yml`
- `yq . .github/workflows/native-prebuild.yml`
- `mix format --check-formatted`

Fixes #61