### PR TITLE
fix: guard native release uploads

### DIFF
--- a/.github/workflows/native-prebuild.yml
+++ b/.github/workflows/native-prebuild.yml
@@ -53,6 +53,46 @@ jobs:
         run: |
           set -euo pipefail
 
+          packages=(
+            duskmoon_hex_solver
+            duskmoon_npm
+            duskmoon_oxc
+            duskmoon_vize
+            duskmoon_oxide
+            duskmoon_quickbeam
+            duskmoon_bundler_runtime
+            duskmoon_bundler
+            phoenix_duskmoon
+          )
+
+          published_packages=()
+          for package in "${packages[@]}"; do
+            if ! status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              "https://hex.pm/api/packages/${package}/releases/${VERSION}")"; then
+              echo "Failed to query Hex package ${package} ${VERSION}" >&2
+              exit 1
+            fi
+
+            case "${status}" in
+              200)
+                published_packages+=("${package}")
+                ;;
+              404)
+                ;;
+              *)
+                echo "Unexpected Hex API status ${status} for ${package} ${VERSION}" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "${#published_packages[@]}" -gt 0 ]; then
+            echo "Refusing to upload native assets for v${VERSION} because Hex already has published packages:" >&2
+            printf '  - %s\n' "${published_packages[@]}" >&2
+            echo "Publish a new patch version instead of replacing GitHub release assets for an already-published Hex version." >&2
+            exit 1
+          fi
+
           if [ "${ALLOW_OVERWRITE}" = "true" ]; then
             echo "Existing release overwrite explicitly allowed for v${VERSION}"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
     with:
       version: ${{ inputs.version }}
       git-ref: ${{ inputs.git-ref }}
-      allow-existing-release-overwrite: true
     secrets: inherit
 
   publish:


### PR DESCRIPTION
## Summary
- stop the full release workflow from bypassing native upload overwrite protection
- fail native prebuilds before uploads when the target version is already published on Hex
- keep published Hex checksums and GitHub release assets from diverging on reruns

Fixes #61