### PR TITLE
fix: make quickbeam zigler optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,7 @@ jobs:
           grep -q "{:duskmoon_hex_solver, \"~> ${VERSION}\"}" apps/duskmoon_npm/mix.exs
           grep -q "{:duskmoon_oxc, \"~> ${VERSION}\"}" apps/duskmoon_quickbeam/mix.exs
           grep -q "{:duskmoon_npm, \"~> ${VERSION}\", optional: true}" apps/duskmoon_quickbeam/mix.exs
+          grep -A1 "{:zigler," apps/duskmoon_quickbeam/mix.exs | grep -q "optional: true, runtime: false"
           if grep -q "{:ex_doc, .*only: :dev" apps/duskmoon_quickbeam/mix.exs; then
             echo "QuickBEAM packaged mix.exs still contains a dev-only ex_doc dependency" >&2
             exit 1

--- a/apps/duskmoon_bundler/mix.exs
+++ b/apps/duskmoon_bundler/mix.exs
@@ -43,6 +43,8 @@ defmodule DuskmoonBundler.MixProject do
       {:duskmoon_vize, in_umbrella: true},
       {:duskmoon_oxide, in_umbrella: true},
       {:duskmoon_quickbeam, in_umbrella: true},
+      {:zigler, "~> 0.13.0 or ~> 0.14.0 or ~> 0.15.0 or ~> 0.16.0",
+       only: [:dev, :test], runtime: false},
       {:rustler, "~> 0.36 or ~> 0.37 or ~> 0.38", optional: true, runtime: false},
       {:dotenvy, "~> 1.1"},
       {:floki, "~> 0.38"},

--- a/apps/duskmoon_quickbeam/mix.exs
+++ b/apps/duskmoon_quickbeam/mix.exs
@@ -69,7 +69,8 @@ defmodule QuickBEAM.MixProject do
   defp deps do
     [
       {:zigler_precompiled, "~> 0.1.4", runtime: false},
-      {:zigler, "~> 0.13.0 or ~> 0.14.0 or ~> 0.15.0 or ~> 0.16.0", runtime: false},
+      {:zigler, "~> 0.13.0 or ~> 0.14.0 or ~> 0.15.0 or ~> 0.16.0",
+       optional: true, runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:ex_dna, "~> 1.1", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
## Summary
- mark QuickBEAM's Zigler source-build dependency optional in Hex metadata
- keep Zigler available for source builds while avoiding required downstream installs for precompiled artifacts
- add a release workflow assertion so packaged QuickBEAM metadata keeps Zigler optional

Fixes #65