### PR TITLE
fix: document oxc checksum cache recovery

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime.ex
@@ -63,15 +63,30 @@ defmodule DuskmoonBundler.JS.Runtime do
     end
   end
 
+  @spec ensure_and_call(keyword(), String.t(), list(), keyword()) :: QuickBEAM.js_result()
+  def ensure_and_call(opts, function, args \\ [], call_opts \\ []) do
+    do_ensure_and_call(opts, function, args, call_opts, 2)
+  end
+
   @spec call(t() | GenServer.server(), String.t(), list(), keyword()) :: QuickBEAM.js_result()
   def call(runtime, function, args \\ [], opts \\ [])
 
   def call(%__MODULE__{pid: pid}, function, args, opts) do
-    QuickBEAM.call(pid, function, args, opts)
+    if Process.alive?(pid) do
+      QuickBEAM.call(pid, function, args, opts)
+    else
+      {:error, {:runtime_down, :noproc}}
+    end
+  catch
+    :exit, {:noproc, _} = reason ->
+      {:error, {:runtime_down, reason}}
   end
 
   def call(runtime, function, args, opts) do
     QuickBEAM.call(runtime, function, args, opts)
+  catch
+    :exit, {:noproc, _} = reason ->
+      {:error, {:runtime_down, reason}}
   end
 
   @spec stop(t() | GenServer.server()) :: :ok
@@ -96,6 +111,18 @@ defmodule DuskmoonBundler.JS.Runtime do
     case start(opts) do
       {:ok, runtime} -> runtime
       {:error, error} -> raise error
+    end
+  end
+
+  defp do_ensure_and_call(opts, function, args, call_opts, attempts_left) do
+    runtime = ensure!(opts)
+
+    case call(runtime, function, args, call_opts) do
+      {:error, {:runtime_down, _reason}} when attempts_left > 1 ->
+        do_ensure_and_call(opts, function, args, call_opts, attempts_left - 1)
+
+      result ->
+        result
     end
   end
 

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
@@ -102,8 +102,9 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
          {:ok, policy} <- Lockfile.read_policy(lockfile_path),
          true <- Lockfile.policy_matches?(policy),
          {:ok, lockfile} when lockfile != %{} <- Lockfile.read(lockfile_path) do
-      Enum.all?(lockfile, fn {name, _} ->
-        File.exists?(Path.join([node_modules, name, "package.json"]))
+      Enum.all?(lockfile, fn {name, entry} ->
+        File.exists?(Path.join([node_modules, name, "package.json"])) and
+          NPM.Cache.cached?(name, entry.version)
       end)
     else
       _ -> false

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/plugin/solid.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/plugin/solid.ex
@@ -63,22 +63,15 @@ defmodule DuskmoonBundler.Plugin.Solid do
   def runtime_packages, do: @runtime_packages
 
   defp do_compile(source, filename, opts, plugin_opts) do
-    runtime =
-      DuskmoonBundler.JS.Runtime.ensure!(
-        name: @runtime_name,
-        packages: @runtime_packages,
-        apis: [:browser, :node],
-        entry: {:duskmoon_bundler_asset, "frameworks/solid.ts"},
-        bundle: true,
-        max_stack_size: 32 * 1024 * 1024
-      )
-
     compile_options =
       filename
       |> DuskmoonBundler.Plugin.Solid.CompilerOptions.new(opts, plugin_opts)
       |> Jason.encode!()
 
-    case DuskmoonBundler.JS.Runtime.call(runtime, "compileSolid", [source, compile_options]) do
+    case DuskmoonBundler.JS.Runtime.ensure_and_call(runtime_opts(), "compileSolid", [
+           source,
+           compile_options
+         ]) do
       {:ok, %{"code" => code, "map" => map}} ->
         with {:ok, code, downlevelled?} <- maybe_downlevel(code, filename, opts) do
           {:ok,
@@ -100,6 +93,17 @@ defmodule DuskmoonBundler.Plugin.Solid do
       {:error, _} = error ->
         error
     end
+  end
+
+  defp runtime_opts do
+    [
+      name: @runtime_name,
+      packages: @runtime_packages,
+      apis: [:browser, :node],
+      entry: {:duskmoon_bundler_asset, "frameworks/solid.ts"},
+      bundle: true,
+      max_stack_size: 32 * 1024 * 1024
+    ]
   end
 
   defp maybe_downlevel(code, filename, opts) do

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/plugin/svelte.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/plugin/svelte.ex
@@ -79,22 +79,15 @@ defmodule DuskmoonBundler.Plugin.Svelte do
   def runtime_packages, do: @runtime_packages
 
   defp do_compile(path, source, opts, plugin_opts) do
-    runtime =
-      DuskmoonBundler.JS.Runtime.ensure!(
-        name: @runtime_name,
-        packages: @runtime_packages,
-        apis: [:browser, :node],
-        entry: {:duskmoon_bundler_asset, "frameworks/svelte.ts"},
-        bundle: true,
-        max_stack_size: 16 * 1024 * 1024
-      )
-
     compile_options =
       path
       |> DuskmoonBundler.Plugin.Svelte.CompilerOptions.new(opts, plugin_opts)
       |> Jason.encode!()
 
-    case DuskmoonBundler.JS.Runtime.call(runtime, "compileSvelte", [source, compile_options]) do
+    case DuskmoonBundler.JS.Runtime.ensure_and_call(runtime_opts(), "compileSvelte", [
+           source,
+           compile_options
+         ]) do
       {:ok, %{"js" => js, "css" => css, "jsMap" => js_map} = result} ->
         {:ok,
          %DuskmoonBundler.Pipeline.Result{
@@ -115,6 +108,17 @@ defmodule DuskmoonBundler.Plugin.Svelte do
       {:error, _} = error ->
         error
     end
+  end
+
+  defp runtime_opts do
+    [
+      name: @runtime_name,
+      packages: @runtime_packages,
+      apis: [:browser, :node],
+      entry: {:duskmoon_bundler_asset, "frameworks/svelte.ts"},
+      bundle: true,
+      max_stack_size: 16 * 1024 * 1024
+    ]
   end
 
   defp do_extract_imports(path, source, opts) do

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/js/runtime_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/js/runtime_test.exs
@@ -27,4 +27,13 @@ defmodule DuskmoonBundler.JS.RuntimeTest do
       Runtime.ensure!(name: name, packages: %{}, install_dir: second_dir)
     end
   end
+
+  test "call returns runtime_down when the runtime pid is stale" do
+    parent = self()
+    pid = spawn(fn -> send(parent, :done) end)
+
+    assert_receive :done
+    refute Process.alive?(pid)
+    assert {:error, {:runtime_down, :noproc}} = Runtime.call(%Runtime{pid: pid}, "noop", [])
+  end
 end

--- a/apps/duskmoon_npm/lib/npm/cache.ex
+++ b/apps/duskmoon_npm/lib/npm/cache.ex
@@ -1,6 +1,8 @@
 defmodule NPM.Cache do
   alias NPM.Security.RegistryPolicy
 
+  @complete_marker ".npm-ex-cache-complete"
+
   @moduledoc """
   Global package cache.
 
@@ -24,7 +26,9 @@ defmodule NPM.Cache do
   @doc "Check if a package version is already cached."
   @spec cached?(String.t(), String.t()) :: boolean()
   def cached?(name, version) do
-    File.exists?(Path.join(package_dir(name, version), "package.json"))
+    name
+    |> package_dir(version)
+    |> cache_intact?()
   end
 
   @doc """
@@ -37,30 +41,34 @@ defmodule NPM.Cache do
   @spec ensure(String.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, String.t()} | {:ok, :missing_optional} | {:error, term()}
   def ensure(name, version, tarball_url, integrity, opts \\ []) do
-    dest = package_dir(name, version)
+    with_lock(name, version, fn ->
+      dest = package_dir(name, version)
 
-    if cached?(name, version) do
-      {:ok, dest}
-    else
-      try do
-        RegistryPolicy.validate_url!(tarball_url)
+      if cached?(name, version) do
+        {:ok, dest}
+      else
+        try do
+          RegistryPolicy.validate_url!(tarball_url)
+          File.rm_rf(dest)
 
-        case fetch_and_extract(
-               candidate_tarball_urls(name, version, tarball_url, integrity),
-               integrity,
-               dest
-             ) do
-          {:ok, _count} ->
-            {:ok, dest}
+          case fetch_and_extract(
+                 candidate_tarball_urls(name, version, tarball_url, integrity),
+                 integrity,
+                 dest
+               ) do
+            {:ok, _count} ->
+              write_complete_marker!(dest)
+              {:ok, dest}
 
-          {:error, reason} ->
-            handle_fetch_error({:fetch_failed, name, version, reason}, dest, opts)
+            {:error, reason} ->
+              handle_fetch_error({:fetch_failed, name, version, reason}, dest, opts)
+          end
+        rescue
+          error in RegistryPolicy.Error ->
+            handle_fetch_error(error, dest, opts)
         end
-      rescue
-        error in RegistryPolicy.Error ->
-          handle_fetch_error(error, dest, opts)
       end
-    end
+    end)
   end
 
   @doc false
@@ -113,11 +121,28 @@ defmodule NPM.Cache do
   end
 
   defp handle_fetch_error(reason, dest, opts) do
+    File.rm_rf(dest)
+
     if Keyword.get(opts, :optional?, false) do
-      File.rm_rf(dest)
       {:ok, :missing_optional}
     else
       {:error, reason}
     end
+  end
+
+  defp with_lock(name, version, fun) do
+    :global.trans({__MODULE__, {name, version}}, fun, [node()], :infinity)
+  end
+
+  defp write_complete_marker!(dest) do
+    File.write!(Path.join(dest, @complete_marker), "1\n")
+  end
+
+  defp complete_marker?(dest) do
+    File.regular?(Path.join(dest, @complete_marker))
+  end
+
+  defp cache_intact?(dest) do
+    File.regular?(Path.join(dest, "package.json")) and complete_marker?(dest)
   end
 end

--- a/apps/duskmoon_npm/test/npm/cache_test.exs
+++ b/apps/duskmoon_npm/test/npm/cache_test.exs
@@ -6,12 +6,24 @@ defmodule NPM.CacheTest do
   setup do
     old_env = System.get_env("NPM_EX_ALLOWED_REGISTRIES")
     old_allowed = Application.get_env(:duskmoon_npm, :allowed_registries)
+    old_cache_dir = Application.get_env(:duskmoon_npm, :cache_dir)
+
+    tmp_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "npm_cache_test_#{System.unique_integer([:positive])}"
+      ])
 
     System.delete_env("NPM_EX_ALLOWED_REGISTRIES")
+    Application.put_env(:duskmoon_npm, :cache_dir, Path.join(tmp_dir, "cache-root"))
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(tmp_dir)
 
     on_exit(fn ->
       restore_env("NPM_EX_ALLOWED_REGISTRIES", old_env)
       restore_app_env(:allowed_registries, old_allowed)
+      restore_app_env(:cache_dir, old_cache_dir)
+      File.rm_rf!(tmp_dir)
     end)
   end
 
@@ -75,6 +87,22 @@ defmodule NPM.CacheTest do
                original,
                "https://registry.npmjs.org/@scope%2fpackage/-/package-1.2.3.tgz"
              ]
+  end
+
+  test "does not reuse partially extracted package caches" do
+    cache_path = Cache.package_dir("partial-package", "1.0.0")
+    File.mkdir_p!(cache_path)
+
+    File.write!(
+      Path.join(cache_path, "package.json"),
+      NPM.JSON.encode_pretty(%{"name" => "partial-package", "version" => "1.0.0"})
+    )
+
+    refute Cache.cached?("partial-package", "1.0.0")
+
+    File.write!(Path.join(cache_path, ".npm-ex-cache-complete"), "1\n")
+
+    assert Cache.cached?("partial-package", "1.0.0")
   end
 
   defp restore_env(key, nil), do: System.delete_env(key)

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -78,6 +78,8 @@ defmodule NPM.Install.LinkerTest do
       NPM.JSON.encode_pretty(%{"name" => name, "version" => version})
     )
 
+    File.write!(Path.join(cache_path, ".npm-ex-cache-complete"), "1\n")
+
     cache_path
   end
 

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -236,6 +236,8 @@ defmodule NPM.InstallTest do
       NPM.JSON.encode_pretty(%{"name" => name, "version" => version})
     )
 
+    File.write!(Path.join(cache_path, ".npm-ex-cache-complete"), "1\n")
+
     cache_path
   end
 

--- a/apps/duskmoon_oxc/README.md
+++ b/apps/duskmoon_oxc/README.md
@@ -33,6 +33,32 @@ end
 Precompiled NIFs are available for macOS (aarch64, x86_64) and Linux (aarch64, x86_64, musl).
 Building from source requires a Rust toolchain (`rustup` recommended).
 
+### Precompiled NIF Checksum Recovery
+
+`duskmoon_oxc` verifies every downloaded precompiled NIF against the checksum
+files shipped in the Hex package. If compilation fails with:
+
+```text
+Error while downloading precompiled NIF: the integrity check failed because the checksum of files does not match.
+```
+
+the usual cause is a stale or partially downloaded Rustler precompiled cache.
+Compile once with an empty cache to force a clean download:
+
+```sh
+mix deps.clean duskmoon_oxc --build
+RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH="$(mktemp -d)" mix compile
+```
+
+For CI or reproducible shells, set `RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH` to a
+stable cache directory controlled by the project. To bypass precompiled
+downloads completely, build the NIFs from source:
+
+```sh
+mix deps.clean duskmoon_oxc --build
+DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix compile
+```
+
 ## Usage
 
 Source-taking APIs accept binaries and `iodata()`.


### PR DESCRIPTION
## Summary
- Document the verified clean-cache recovery path for stale Rustler precompiled NIF checksum failures
- Document the source-build fallback using the existing DUSKMOON_BUILD_NATIVE_FROM_SOURCE override

Fixes #69