### PR TITLE
fix: avoid hex solver struct update warning

### DIFF
--- a/apps/duskmoon_hex_solver/lib/hex_solver/incompatibility.ex
+++ b/apps/duskmoon_hex_solver/lib/hex_solver/incompatibility.ex
@@ -407,7 +407,7 @@ defmodule HexSolver.Incompatibility do
     end
   end
 
-  defp term_abs(term), do: %Term{term | positive: true}
+  defp term_abs(%Term{} = term), do: %{term | positive: true}
 
   defp bright_term_abs(term, opts), do: bright(term_abs(term), opts)
 


### PR DESCRIPTION
## Summary
- Pattern-match `term_abs/1` on `HexSolver.Term` before updating `positive`
- Use the same map-update style as the term inverse helper

## Verification
- `mix compile --warnings-as-errors --force` from `apps/duskmoon_hex_solver`
- `mix test test/hex_solver_test.exs` from `apps/duskmoon_hex_solver`

Fixes #72