### PR TITLE
fix: add oxc musl prebuilt target

### DIFF
--- a/.github/workflows/native-prebuild.yml
+++ b/.github/workflows/native-prebuild.yml
@@ -148,6 +148,31 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
             use-cross: false
+        include:
+          - crate:
+              app: duskmoon_oxc
+              name: oxc_ex_nif
+              project-dir: apps/duskmoon_oxc/native/oxc_ex_nif
+            target:
+              target: x86_64-unknown-linux-musl
+              os: ubuntu-22.04
+              use-cross: true
+          - crate:
+              app: duskmoon_oxc
+              name: oxc_fmt_nif
+              project-dir: apps/duskmoon_oxc/native/oxc_fmt_nif
+            target:
+              target: x86_64-unknown-linux-musl
+              os: ubuntu-22.04
+              use-cross: true
+          - crate:
+              app: duskmoon_oxc
+              name: oxc_lint_nif
+              project-dir: apps/duskmoon_oxc/native/oxc_lint_nif
+            target:
+              target: x86_64-unknown-linux-musl
+              os: ubuntu-22.04
+              use-cross: true
 
     steps:
       - name: Checkout code

--- a/apps/duskmoon_oxc/lib/oxc/format/native.ex
+++ b/apps/duskmoon_oxc/lib/oxc/format/native.ex
@@ -20,6 +20,7 @@ defmodule OXC.Format.Native do
       x86_64-pc-windows-gnu
       x86_64-unknown-freebsd
       x86_64-unknown-linux-gnu
+      x86_64-unknown-linux-musl
     ),
     version: native_version
 

--- a/apps/duskmoon_oxc/lib/oxc/lint/native.ex
+++ b/apps/duskmoon_oxc/lib/oxc/lint/native.ex
@@ -20,6 +20,7 @@ defmodule OXC.Lint.Native do
       x86_64-pc-windows-gnu
       x86_64-unknown-freebsd
       x86_64-unknown-linux-gnu
+      x86_64-unknown-linux-musl
     ),
     version: native_version
 

--- a/apps/duskmoon_oxc/lib/oxc/native.ex
+++ b/apps/duskmoon_oxc/lib/oxc/native.ex
@@ -18,6 +18,7 @@ defmodule OXC.Native do
       x86_64-pc-windows-gnu
       x86_64-unknown-freebsd
       x86_64-unknown-linux-gnu
+      x86_64-unknown-linux-musl
     ),
     version: native_version
 


### PR DESCRIPTION
## Summary
- Add `x86_64-unknown-linux-musl` to all three `duskmoon_oxc` RustlerPrecompiled target lists
- Add OXC-only musl rows to the native prebuild workflow so release assets are generated for Alpine Linux

## Verification
- `mix format --check-formatted apps/duskmoon_oxc/lib/oxc/native.ex apps/duskmoon_oxc/lib/oxc/format/native.ex apps/duskmoon_oxc/lib/oxc/lint/native.ex`
- `mix compile --warnings-as-errors --force` from `apps/duskmoon_oxc`
- `yq . .github/workflows/native-prebuild.yml >/dev/null`

Fixes #71