### PR TITLE
fix: re-resolve stale npm workspace locks

### DIFF
--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -280,8 +280,11 @@ defmodule NPM do
   end
 
   defp lockfile_covers_dependencies?(lockfile, deps) do
-    Enum.all?(deps, fn {name, _range} ->
-      Map.has_key?(lockfile, name)
+    Enum.all?(deps, fn {name, range} ->
+      case Map.get(lockfile, name) do
+        nil -> false
+        entry -> lockfile_entry_satisfies_range?(entry, range)
+      end
     end) and
       Enum.all?(lockfile, fn {name, _entry} ->
         Map.has_key?(deps, name) or
@@ -290,6 +293,16 @@ defmodule NPM do
               Map.has_key?(Map.get(e, :optional_dependencies, %{}), name)
           end)
       end)
+  end
+
+  defp lockfile_entry_satisfies_range?(_entry, range) when range in ["", "*", "latest"],
+    do: true
+
+  defp lockfile_entry_satisfies_range?(entry, range) do
+    case NPM.Alias.parse(range) do
+      {:alias, _package, alias_range} -> NPMSemver.matches?(entry.version, alias_range)
+      {:normal, normal_range} -> NPMSemver.matches?(entry.version, normal_range)
+    end
   end
 
   defp lockfile_dependency_records_complete?(lockfile) do

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -172,6 +172,48 @@ defmodule NPM.InstallTest do
     refute File.exists?(Path.join(app_dir, "node_modules"))
   end
 
+  test "re-resolves stale workspace dependency ranges", %{project_dir: project_dir} do
+    package = "workspace-stale-package"
+    old_version = "0.2.0"
+    new_version = "1.5.5"
+    old_cache_path = write_cached_package!(package, old_version)
+    new_cache_path = write_cached_package!(package, new_version)
+    app_dir = Path.join([project_dir, "apps", "web"])
+
+    put_packument!(package, new_version)
+
+    write_package!(project_dir, %{
+      "name" => "workspace_root",
+      "private" => true,
+      "workspaces" => ["apps/*"]
+    })
+
+    write_package!(app_dir, %{
+      "name" => "web",
+      "version" => "1.0.0",
+      "dependencies" => %{package => new_version}
+    })
+
+    assert :ok = NPM.Lockfile.write(%{package => lock_entry(package, old_version)})
+
+    node_modules = Path.join(project_dir, "node_modules")
+    File.mkdir_p!(node_modules)
+    File.ln_s!(old_cache_path, Path.join(node_modules, package))
+    File.cd!(app_dir)
+
+    output =
+      capture_io(fn ->
+        assert :ok = NPM.install()
+      end)
+
+    refute output =~ "Already up to date."
+    assert {:ok, ^new_cache_path} = File.read_link(Path.join(node_modules, package))
+    assert {:ok, ^app_dir} = File.read_link(Path.join([node_modules, "web"]))
+
+    assert {:ok, lockfile} = NPM.Lockfile.read(Path.join(project_dir, "package-lock.json"))
+    assert lockfile[package].version == new_version
+  end
+
   test "adds dependencies to workspace package and installs at workspace root", %{
     project_dir: project_dir
   } do


### PR DESCRIPTION
## Summary
- make the npm lockfile fast path verify direct locked versions satisfy current package.json ranges
- keep wildcard-style ranges such as latest and * compatible with existing current-lock behavior
- add a workspace regression test for changing a dependency from 0.2.0 to 1.5.5

## Verification
- mix test apps/duskmoon_npm/test/npm/install_test.exs
- mix compile --warnings-as-errors
- mix format --check-formatted apps/duskmoon_npm/lib/npm.ex apps/duskmoon_npm/test/npm/install_test.exs

Fixes #75