### PR TITLE
fix: add git repository view components

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Components that require hooks:
 ## Available Components
 
 - **Action**: buttons, dropdowns, links, menus, toggles
-- **Data Display**: accordion, avatar, badge, card, chip, collapse, flash, list, markdown, pagination, popover, progress, skeleton, stat, table, timeline, tooltip
+- **Data Display**: accordion, avatar, badge, card, chip, collapse, flash, git repository, list, markdown, pagination, popover, progress, skeleton, stat, table, timeline, tooltip
 - **Data Entry**: autocomplete, cascader, checkbox, compact input, file upload, form, input, multi-select, OTP input, PIN input, radio, rating, segment control, select, slider, switch, textarea, time input, tree select
 - **Feedback**: dialog, loading, snackbar, toast
 - **Navigation**: actionbar, appbar, bottom nav, breadcrumb, left menu, navbar, nested menu, page footer, page header, stepper, steps, tabs

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/components/layouts/app.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/components/layouts/app.html.heex
@@ -55,6 +55,36 @@
         <:menu id="data-display-flash" to={~p"/components/data-display/flash"}>
           <.dm_mdi name="flash" class="w-4 h-4" /> Flash
         </:menu>
+        <:menu
+          id="data-display-git-repository-header"
+          to={~p"/components/data-display/git-repository-header"}
+        >
+          <.dm_mdi name="source-repository" class="w-4 h-4" /> Git Repository Header
+        </:menu>
+        <:menu
+          id="data-display-git-repository-nav"
+          to={~p"/components/data-display/git-repository-nav"}
+        >
+          <.dm_mdi name="tab" class="w-4 h-4" /> Git Repository Nav
+        </:menu>
+        <:menu id="data-display-git-file-tree" to={~p"/components/data-display/git-file-tree"}>
+          <.dm_mdi name="file-tree-outline" class="w-4 h-4" /> Git File Tree
+        </:menu>
+        <:menu
+          id="data-display-git-blob-viewer"
+          to={~p"/components/data-display/git-blob-viewer"}
+        >
+          <.dm_mdi name="file-code-outline" class="w-4 h-4" /> Git Blob Viewer
+        </:menu>
+        <:menu
+          id="data-display-git-commit-diff"
+          to={~p"/components/data-display/git-commit-diff"}
+        >
+          <.dm_mdi name="source-commit" class="w-4 h-4" /> Git Commit Diff
+        </:menu>
+        <:menu id="data-display-git-clone-box" to={~p"/components/data-display/git-clone-box"}>
+          <.dm_mdi name="source-branch-sync" class="w-4 h-4" /> Git Clone Box
+        </:menu>
         <:menu id="data-display-markdown" to={~p"/components/data-display/markdown"}>
           <.dm_bsi name="markdown" class="w-4 h-4" /> Markdown
         </:menu>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_controller.ex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_controller.ex
@@ -33,6 +33,30 @@ defmodule DuskmoonStorybookWeb.Components.DataDisplayController do
     render(conn, :flash, active_menu: "data-display-flash")
   end
 
+  def git_repository_header(conn, _params) do
+    render(conn, :git_repository_header, active_menu: "data-display-git-repository-header")
+  end
+
+  def git_repository_nav(conn, _params) do
+    render(conn, :git_repository_nav, active_menu: "data-display-git-repository-nav")
+  end
+
+  def git_file_tree(conn, _params) do
+    render(conn, :git_file_tree, active_menu: "data-display-git-file-tree")
+  end
+
+  def git_blob_viewer(conn, _params) do
+    render(conn, :git_blob_viewer, active_menu: "data-display-git-blob-viewer")
+  end
+
+  def git_commit_diff(conn, _params) do
+    render(conn, :git_commit_diff, active_menu: "data-display-git-commit-diff")
+  end
+
+  def git_clone_box(conn, _params) do
+    render(conn, :git_clone_box, active_menu: "data-display-git-clone-box")
+  end
+
   def markdown(conn, _params) do
     render(conn, :markdown, active_menu: "data-display-markdown")
   end

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_blob_viewer.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_blob_viewer.html.heex
@@ -21,13 +21,28 @@
   """ %>
   <.dm_markdown content={md_content} />
 
+  <% router_source = """
+  defmodule FornacastWeb.Router do
+    use FornacastWeb, :router
+
+    scope "/", FornacastWeb do
+      pipe_through :browser
+      get "/", PageController, :home
+    end
+  end
+  """ %>
+  <% truncated_source = """
+  export const generated = true;
+  // preview only
+  """ %>
+
   <h3 class="text-xl font-semibold mt-8 mb-4">Source File</h3>
   <.dm_git_blob_viewer
     filename="lib/fornacast_web/router.ex"
     size="348 B"
     language="elixir"
     raw_href="#"
-    content={"defmodule FornacastWeb.Router do\n  use FornacastWeb, :router\n\n  scope \"/\", FornacastWeb do\n    pipe_through :browser\n    get \"/\", PageController, :home\n  end\nend\n"}
+    content={router_source}
   />
 
   <h3 class="text-xl font-semibold mt-8 mb-4">Truncated Source</h3>
@@ -36,7 +51,7 @@
     size="1.8 MB"
     language="javascript"
     truncated
-    content="export const generated = true;\n// preview only\n"
+    content={truncated_source}
   />
 
   <h3 class="text-xl font-semibold mt-8 mb-4">Binary and Non-UTF-8 States</h3>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_blob_viewer.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_blob_viewer.html.heex
@@ -1,0 +1,47 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-blob-viewer"}>Data Display</:crumb>
+  <:crumb>Git Blob Viewer</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git Blob Viewer</span>
+    <span class="text-sm opacity-60">dm_git_blob_viewer</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Read-only source blob panel with file metadata, raw and copy actions, and
+  binary, non-UTF-8, and truncated file states.
+
+  ## Usage
+  ```elixir
+  <.dm_git_blob_viewer filename="lib/app.ex" language="elixir" content={@source} />
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Source File</h3>
+  <.dm_git_blob_viewer
+    filename="lib/fornacast_web/router.ex"
+    size="348 B"
+    language="elixir"
+    raw_href="#"
+    content={"defmodule FornacastWeb.Router do\n  use FornacastWeb, :router\n\n  scope \"/\", FornacastWeb do\n    pipe_through :browser\n    get \"/\", PageController, :home\n  end\nend\n"}
+  />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Truncated Source</h3>
+  <.dm_git_blob_viewer
+    filename="priv/static/large-generated-file.js"
+    size="1.8 MB"
+    language="javascript"
+    truncated
+    content="export const generated = true;\n// preview only\n"
+  />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Binary and Non-UTF-8 States</h3>
+  <div class="grid gap-4 lg:grid-cols-2">
+    <.dm_git_blob_viewer filename="priv/static/logo.png" size="24 KB" binary />
+    <.dm_git_blob_viewer filename="legacy/shift_jis.txt" size="8 KB" non_utf8 />
+  </div>
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_clone_box.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_clone_box.html.heex
@@ -1,0 +1,46 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-clone-box"}>Data Display</:crumb>
+  <:crumb>Git Clone Box</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git Clone Box</span>
+    <span class="text-sm opacity-60">dm_git_clone_box</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Clone URL and command snippets for existing and empty repositories. It renders
+  copy affordances for HTTPS, SSH, and command rows.
+
+  ## Usage
+  ```elixir
+  <.dm_git_clone_box clone_url="https://github.com/example/repo.git" ssh_url="git@github.com:example/repo.git" />
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Clone Existing Repository</h3>
+  <.dm_git_clone_box
+    clone_url="https://github.com/duskmoon-dev/phoenix-duskmoon-ui.git"
+    ssh_url="git@github.com:duskmoon-dev/phoenix-duskmoon-ui.git"
+  />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Empty Repository Setup</h3>
+  <.dm_git_clone_box
+    title="Push an existing repository"
+    clone_url="https://github.com/example/new-repository.git"
+    empty
+  />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Custom Commands</h3>
+  <.dm_git_clone_box title="Manual setup">
+    <:url label="HTTPS" value="https://github.com/example/custom.git" />
+    <:command
+      label="Create README"
+      value={"echo '# Custom' > README.md\ngit add README.md\ngit commit -m \"init\""}
+    />
+    <:command label="Push" value="git push -u origin main" />
+  </.dm_git_clone_box>
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_commit_diff.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_commit_diff.html.heex
@@ -1,0 +1,79 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-commit-diff"}>Data Display</:crumb>
+  <:crumb>Git Commit Diff</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git Commit Diff</span>
+    <span class="text-sm opacity-60">dm_git_commit_diff</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Commit metadata with changed-file summaries and unified diff presentation.
+  It supports added, deleted, context, hunk, binary, and truncated states.
+
+  ## Usage
+  ```elixir
+  <.dm_git_commit_diff title="Add repository page" sha={@sha}>
+    <:file path="lib/app.ex" lines={@lines} />
+  </.dm_git_commit_diff>
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Commit Diff</h3>
+  <.dm_git_commit_diff
+    title="Add repository web view components"
+    sha="3a97452d9cf94e8915273e88728f4413e80c0e64"
+    author="Jonathan"
+    committed_at="2 minutes ago"
+    message="Expose DuskMoon-native forge primitives for repository pages."
+    changed_files={2}
+    additions={7}
+    deletions={2}
+  >
+    <:file
+      path="apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/git_repository.ex"
+      status="modified"
+      additions={5}
+      deletions={1}
+      lines={[
+        %{type: :hunk, old_line: nil, new_line: nil, content: "@@ -1,4 +1,8 @@"},
+        %{
+          type: :context,
+          old_line: 1,
+          new_line: 1,
+          content: "defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do"
+        },
+        %{type: :delete, old_line: 2, new_line: nil, content: "  @moduledoc false"},
+        %{
+          type: :add,
+          old_line: nil,
+          new_line: 2,
+          content: "  @moduledoc \"Git repository web view components.\""
+        },
+        %{type: :add, old_line: nil, new_line: 3, content: "  use Phoenix.Component"}
+      ]}
+    />
+    <:file
+      path="apps/duskmoon_storybook/assets/images/repository-preview.png"
+      status="added"
+      additions={2}
+      deletions={1}
+      binary
+    />
+  </.dm_git_commit_diff>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Truncated Diff</h3>
+  <.dm_git_commit_diff title="Update generated bundle" sha="a13f9c2">
+    <:file
+      path="priv/static/assets/app.js"
+      status="modified"
+      additions={4200}
+      deletions={3900}
+      truncated
+    />
+  </.dm_git_commit_diff>
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_file_tree.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_file_tree.html.heex
@@ -1,0 +1,57 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-file-tree"}>Data Display</:crumb>
+  <:crumb>Git File Tree</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git File Tree</span>
+    <span class="text-sm opacity-60">dm_git_file_tree</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Dense file tree rows for folders, files, submodules, symlinks, and empty
+  repository states. Rows accept normal Phoenix route links.
+
+  ## Usage
+  ```elixir
+  <.dm_git_file_tree>
+    <:row kind="folder" name="lib" path="lib" href="/tree/lib" />
+    <:row kind="file" name="mix.exs" path="mix.exs" href="/blob/mix.exs" />
+  </.dm_git_file_tree>
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Source Tree</h3>
+  <.dm_git_file_tree>
+    <:row kind="folder" name="apps" path="apps" href="#" meta="8 entries" />
+    <:row kind="folder" name="lib" path="lib" href="#" meta="12 entries" />
+    <:row kind="file" name="mix.exs" path="mix.exs" href="#" meta="4 KB" />
+    <:row kind="file" name="README.md" path="README.md" href="#" meta="12 KB" />
+    <:row
+      kind="submodule"
+      name="vendor/duskmoon-theme"
+      path="vendor/duskmoon-theme"
+      href="#"
+      meta="a13f9c2"
+    />
+    <:row kind="symlink" name="assets/current" path="assets/current" href="#" meta="symlink" />
+  </.dm_git_file_tree>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Long Paths</h3>
+  <.dm_git_file_tree>
+    <:row
+      kind="file"
+      name="component_with_a_very_long_filename_that_should_wrap_without_breaking_layout.ex"
+      path="apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/component_with_a_very_long_filename_that_should_wrap_without_breaking_layout.ex"
+      href="#"
+      meta="18 KB"
+      active
+    />
+  </.dm_git_file_tree>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Empty Repository</h3>
+  <.dm_git_file_tree empty_message="No files on this branch." />
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_repository_header.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_repository_header.html.heex
@@ -1,0 +1,52 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-repository-header"}>Data Display</:crumb>
+  <:crumb>Git Repository Header</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git Repository Header</span>
+    <span class="text-sm opacity-60">dm_git_repository_header</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Repository header for forge-style pages. It renders owner/name identity,
+  visibility, default ref, description, metadata, and action slots.
+
+  ## Usage
+  ```elixir
+  <.dm_git_repository_header owner="duskmoon-dev" name="phoenix-duskmoon-ui" visibility="public">
+    <:meta icon="source-commit">b91d64a</:meta>
+    <:action><.dm_btn size="sm">Settings</.dm_btn></:action>
+  </.dm_git_repository_header>
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Repository Overview</h3>
+  <.dm_git_repository_header
+    owner="duskmoon-dev"
+    name="phoenix-duskmoon-ui"
+    visibility="public"
+    default_ref="main"
+    description="DuskMoon UI component library for Phoenix applications."
+  >
+    <:meta icon="source-commit">3a97452</:meta>
+    <:meta icon="star-outline">128 stars</:meta>
+    <:meta icon="clock-outline">Updated 2 minutes ago</:meta>
+    <:action><a href="#" class="btn btn-sm">Watch</a></:action>
+    <:action><a href="#" class="btn btn-sm">Settings</a></:action>
+  </.dm_git_repository_header>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Long Repository Name</h3>
+  <.dm_git_repository_header
+    owner="example-organization-with-a-long-name"
+    name="repository-with-a-very-long-name-that-should-wrap-without-overflowing"
+    visibility="private"
+    default_ref="feature/very-long-branch-name-for-release-review"
+    description="The header keeps repository names, refs, and descriptions readable when forge data contains long strings."
+  >
+    <:meta icon="lock-outline">Private access</:meta>
+  </.dm_git_repository_header>
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_repository_nav.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/git_repository_nav.html.heex
@@ -1,0 +1,42 @@
+<.dm_breadcrumb class="px-4">
+  <:crumb to={~p"/components/data-display/git-repository-nav"}>Data Display</:crumb>
+  <:crumb>Git Repository Nav</:crumb>
+</.dm_breadcrumb>
+
+<.dm_card class="w-full h-full overflow-auto" body_class="p-4">
+  <:title class="flex flex-row justify-center items-center gap-3">
+    <span class="text-4xl text-primary">Git Repository Nav</span>
+    <span class="text-sm opacity-60">dm_git_repository_nav</span>
+  </:title>
+
+  <% md_content = """
+  ## Overview
+  Server-rendered repository navigation for Code, Commits, Branches, Tags,
+  and settings-style tabs. Items accept `href`, `navigate`, or `patch`.
+
+  ## Usage
+  ```elixir
+  <.dm_git_repository_nav>
+    <:item label="Code" href="/repo" active />
+    <:item label="Commits" navigate="/repo/commits" count={42} />
+  </.dm_git_repository_nav>
+  ```
+  """ %>
+  <.dm_markdown content={md_content} />
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Repository Sections</h3>
+  <.dm_git_repository_nav>
+    <:item label="Code" href="#" icon="code-tags" active />
+    <:item label="Commits" href="#" icon="source-commit" count={42} />
+    <:item label="Branches" href="#" icon="source-branch" count={7} />
+    <:item label="Tags" href="#" icon="tag-outline" />
+    <:item label="Settings" href="#" icon="cog-outline" />
+  </.dm_git_repository_nav>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Long Labels</h3>
+  <.dm_git_repository_nav label="Repository admin navigation">
+    <:item label="Repository Activity Overview" href="#" icon="chart-timeline-variant" active />
+    <:item label="Protected Branch Rules" href="#" icon="shield-check-outline" count={12} />
+    <:item label="Deployment Keys And Access Tokens" href="#" icon="key-outline" />
+  </.dm_git_repository_nav>
+</.dm_card>

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/page_html/page.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/page_html/page.html.heex
@@ -386,6 +386,42 @@
           </.link>
           <.link
             class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-repository-header"}
+          >
+            <.dm_mdi name="source-repository" class="w-4 h-4 opacity-50" /> Git Header
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-repository-nav"}
+          >
+            <.dm_mdi name="tab" class="w-4 h-4 opacity-50" /> Git Nav
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-file-tree"}
+          >
+            <.dm_mdi name="file-tree-outline" class="w-4 h-4 opacity-50" /> Git Tree
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-blob-viewer"}
+          >
+            <.dm_mdi name="file-code-outline" class="w-4 h-4 opacity-50" /> Git Blob
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-commit-diff"}
+          >
+            <.dm_mdi name="source-commit" class="w-4 h-4 opacity-50" /> Git Diff
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
+            href={~p"/components/data-display/git-clone-box"}
+          >
+            <.dm_mdi name="source-branch-sync" class="w-4 h-4 opacity-50" /> Git Clone
+          </.link>
+          <.link
+            class="dm-comp-link flex items-center gap-2 text-sm"
             href={~p"/components/data-display/markdown"}
           >
             <.dm_bsi name="markdown" class="w-4 h-4 opacity-50" /> Markdown

--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/router.ex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/router.ex
@@ -41,6 +41,12 @@ defmodule DuskmoonStorybookWeb.Router do
     get "/data-display/chat", DataDisplayController, :chat
     get "/data-display/chip", DataDisplayController, :chip
     get "/data-display/flash", DataDisplayController, :flash
+    get "/data-display/git-repository-header", DataDisplayController, :git_repository_header
+    get "/data-display/git-repository-nav", DataDisplayController, :git_repository_nav
+    get "/data-display/git-file-tree", DataDisplayController, :git_file_tree
+    get "/data-display/git-blob-viewer", DataDisplayController, :git_blob_viewer
+    get "/data-display/git-commit-diff", DataDisplayController, :git_commit_diff
+    get "/data-display/git-clone-box", DataDisplayController, :git_clone_box
     get "/data-display/markdown", DataDisplayController, :markdown
     get "/data-display/pagination", DataDisplayController, :pagination
     get "/data-display/progress", DataDisplayController, :progress

--- a/apps/duskmoon_storybook/storybook/data_display/git_blob_viewer.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_blob_viewer.story.exs
@@ -13,7 +13,11 @@ defmodule Storybook.DataDisplay.GitBlobViewer do
           filename: "lib/app.ex",
           size: "238 B",
           language: "elixir",
-          content: "defmodule App do\\n  def hello, do: :world\\nend\\n",
+          content: """
+          defmodule App do
+            def hello, do: :world
+          end
+          """,
           raw_href: "#"
         }
       },

--- a/apps/duskmoon_storybook/storybook/data_display/git_blob_viewer.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_blob_viewer.story.exs
@@ -1,0 +1,31 @@
+defmodule Storybook.DataDisplay.GitBlobViewer do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_blob_viewer/1
+  def description, do: "Read-only source blob panel with raw, copy, and file state affordances."
+
+  def variations do
+    [
+      %Variation{
+        id: :source,
+        description: "Text source file",
+        attributes: %{
+          filename: "lib/app.ex",
+          size: "238 B",
+          language: "elixir",
+          content: "defmodule App do\\n  def hello, do: :world\\nend\\n",
+          raw_href: "#"
+        }
+      },
+      %Variation{
+        id: :binary,
+        description: "Binary file state",
+        attributes: %{
+          filename: "priv/static/logo.png",
+          size: "24 KB",
+          binary: true
+        }
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/data_display/git_clone_box.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_clone_box.story.exs
@@ -1,0 +1,27 @@
+defmodule Storybook.DataDisplay.GitCloneBox do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_clone_box/1
+  def description, do: "Clone URL and command snippets for normal and empty repositories."
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Clone existing repository",
+        attributes: %{
+          clone_url: "https://github.com/duskmoon-dev/phoenix-duskmoon-ui.git",
+          ssh_url: "git@github.com:duskmoon-dev/phoenix-duskmoon-ui.git"
+        }
+      },
+      %Variation{
+        id: :empty,
+        description: "Empty repository setup",
+        attributes: %{
+          clone_url: "https://github.com/example/empty.git",
+          empty: true
+        }
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/data_display/git_commit_diff.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_commit_diff.story.exs
@@ -1,0 +1,40 @@
+defmodule Storybook.DataDisplay.GitCommitDiff do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_commit_diff/1
+  def description, do: "Commit metadata with changed-file summaries and unified diff lines."
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Commit with one diff",
+        attributes: %{
+          title: "Add repository components",
+          sha: "b91d64a5f5a2c7e6d9a6",
+          author: "Jonathan",
+          committed_at: "2 minutes ago",
+          changed_files: 1,
+          additions: 2,
+          deletions: 1
+        },
+        slots: [
+          """
+          <:file
+            path="lib/repo_view.ex"
+            status="modified"
+            additions={2}
+            deletions={1}
+            lines={[
+              %{type: :hunk, old_line: nil, new_line: nil, content: "@@ -1,3 +1,4 @@"},
+              %{type: :context, old_line: 1, new_line: 1, content: "defmodule RepoView do"},
+              %{type: :delete, old_line: 2, new_line: nil, content: "  def old, do: :ok"},
+              %{type: :add, old_line: nil, new_line: 2, content: "  def new, do: :ok"}
+            ]}
+          />
+          """
+        ]
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/data_display/git_file_tree.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_file_tree.story.exs
@@ -1,0 +1,28 @@
+defmodule Storybook.DataDisplay.GitFileTree do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_file_tree/1
+  def description, do: "Dense repository file tree rows for folders, files, and submodules."
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Repository file rows",
+        slots: [
+          """
+          <:row kind="folder" name="lib" path="lib" href="#" meta="12 files" />
+          <:row kind="folder" name="test" path="test" href="#" meta="8 files" />
+          <:row kind="file" name="mix.exs" path="mix.exs" href="#" meta="4 KB" />
+          <:row kind="submodule" name="vendor/theme" path="vendor/theme" href="#" meta="a13f9c2" />
+          """
+        ]
+      },
+      %Variation{
+        id: :empty,
+        description: "Empty repository tree",
+        attributes: %{empty_message: "No files on this branch."}
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/data_display/git_repository_header.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_repository_header.story.exs
@@ -1,0 +1,33 @@
+defmodule Storybook.DataDisplay.GitRepositoryHeader do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_repository_header/1
+
+  def description do
+    "Repository header with owner/name, visibility, default ref, metadata, and action slots."
+  end
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Repository identity with metadata and actions",
+        attributes: %{
+          owner: "duskmoon-dev",
+          name: "phoenix-duskmoon-ui",
+          visibility: "public",
+          default_ref: "main",
+          description: "DuskMoon UI component library for Phoenix applications."
+        },
+        slots: [
+          """
+          <:meta icon="source-commit">b91d64a</:meta>
+          <:meta icon="clock-outline">Updated 2m ago</:meta>
+          <:action><a href="#" class="btn btn-sm">Watch</a></:action>
+          <:action><a href="#" class="btn btn-sm">Settings</a></:action>
+          """
+        ]
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/data_display/git_repository_nav.story.exs
+++ b/apps/duskmoon_storybook/storybook/data_display/git_repository_nav.story.exs
@@ -1,0 +1,24 @@
+defmodule Storybook.DataDisplay.GitRepositoryNav do
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PhoenixDuskmoon.Component.DataDisplay.GitRepository.dm_git_repository_nav/1
+  def description, do: "Server-rendered repository navigation for forge pages."
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Repository section links",
+        slots: [
+          """
+          <:item label="Code" href="#" icon="code-tags" active={true} />
+          <:item label="Commits" href="#" icon="source-commit" count={42} />
+          <:item label="Branches" href="#" icon="source-branch" count={3} />
+          <:item label="Tags" href="#" icon="tag-outline" />
+          <:item label="Settings" href="#" icon="cog-outline" />
+          """
+        ]
+      }
+    ]
+  end
+end

--- a/apps/duskmoon_storybook/storybook/index.exs
+++ b/apps/duskmoon_storybook/storybook/index.exs
@@ -85,6 +85,42 @@
       },
       %{
         kind: :story,
+        name: "Git Repository Header",
+        path: "/data_display/git_repository_header",
+        module: Storybook.DataDisplay.GitRepositoryHeader
+      },
+      %{
+        kind: :story,
+        name: "Git Repository Nav",
+        path: "/data_display/git_repository_nav",
+        module: Storybook.DataDisplay.GitRepositoryNav
+      },
+      %{
+        kind: :story,
+        name: "Git File Tree",
+        path: "/data_display/git_file_tree",
+        module: Storybook.DataDisplay.GitFileTree
+      },
+      %{
+        kind: :story,
+        name: "Git Blob Viewer",
+        path: "/data_display/git_blob_viewer",
+        module: Storybook.DataDisplay.GitBlobViewer
+      },
+      %{
+        kind: :story,
+        name: "Git Commit Diff",
+        path: "/data_display/git_commit_diff",
+        module: Storybook.DataDisplay.GitCommitDiff
+      },
+      %{
+        kind: :story,
+        name: "Git Clone Box",
+        path: "/data_display/git_clone_box",
+        module: Storybook.DataDisplay.GitCloneBox
+      },
+      %{
+        kind: :story,
         name: "List",
         path: "/data_display/list",
         module: Storybook.DataDisplay.List

--- a/apps/duskmoon_storybook/test/duskmoon_storybook_web/router_test.exs
+++ b/apps/duskmoon_storybook/test/duskmoon_storybook_web/router_test.exs
@@ -43,4 +43,15 @@ defmodule DuskmoonStorybookWeb.RouterTest do
       end
     end
   end
+
+  describe "git blob viewer page" do
+    test "renders source samples with real newlines", %{conn: conn} do
+      conn = get(conn, "/components/data-display/git-blob-viewer")
+      html = html_response(conn, 200)
+
+      assert html =~ "export const generated = true;\n"
+      assert html =~ "// preview only"
+      refute html =~ "true;\\n// preview only"
+    end
+  end
 end

--- a/apps/duskmoon_storybook/test/duskmoon_storybook_web/router_test.exs
+++ b/apps/duskmoon_storybook/test/duskmoon_storybook_web/router_test.exs
@@ -25,4 +25,22 @@ defmodule DuskmoonStorybookWeb.RouterTest do
       refute router_source =~ "backend_module: Storybook"
     end
   end
+
+  describe "git repository data display routes" do
+    test "renders issue 78 component gallery pages", %{conn: conn} do
+      pages = [
+        {"/components/data-display/git-repository-header", "Git Repository Header"},
+        {"/components/data-display/git-repository-nav", "Git Repository Nav"},
+        {"/components/data-display/git-file-tree", "Git File Tree"},
+        {"/components/data-display/git-blob-viewer", "Git Blob Viewer"},
+        {"/components/data-display/git-commit-diff", "Git Commit Diff"},
+        {"/components/data-display/git-clone-box", "Git Clone Box"}
+      ]
+
+      for {path, title} <- pages do
+        conn = get(recycle(conn), path)
+        assert html_response(conn, 200) =~ title
+      end
+    end
+  end
 end

--- a/apps/phoenix_duskmoon/guides/home.md
+++ b/apps/phoenix_duskmoon/guides/home.md
@@ -53,7 +53,7 @@ See the [Getting Started](getting-started.md) guide for full setup instructions.
 | Category | Examples | Count |
 |----------|----------|-------|
 | [Action](`PhoenixDuskmoon.Component.Action.Button`) | Button, Dropdown, Link, Menu, Toggle | 5 |
-| [Data Display](`PhoenixDuskmoon.Component.DataDisplay.Card`) | Card, Table, Badge, Avatar, Pagination, Timeline | 17 |
+| [Data Display](`PhoenixDuskmoon.Component.DataDisplay.Card`) | Card, Table, Badge, Avatar, Git Repository, Pagination, Timeline | 18 |
 | [Data Entry](`PhoenixDuskmoon.Component.DataEntry.Input`) | Input, Select, Checkbox, Switch, Autocomplete, TreeSelect | 19 |
 | [Feedback](`PhoenixDuskmoon.Component.Feedback.Dialog`) | Dialog, Loading, Snackbar, Toast | 4 |
 | [Navigation](`PhoenixDuskmoon.Component.Navigation.Appbar`) | Appbar, Breadcrumb, Tab, Stepper, PageHeader | 12 |

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component.ex
@@ -68,6 +68,7 @@ defmodule PhoenixDuskmoon.Component do
       import PhoenixDuskmoon.Component.DataDisplay.Card
       import PhoenixDuskmoon.Component.DataDisplay.Chat
       import PhoenixDuskmoon.Component.DataDisplay.Flash
+      import PhoenixDuskmoon.Component.DataDisplay.GitRepository
       import PhoenixDuskmoon.Component.DataDisplay.List
       import PhoenixDuskmoon.Component.DataDisplay.Markdown
       import PhoenixDuskmoon.Component.DataEntry.MarkdownInput

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/git_repository.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/git_repository.ex
@@ -1,0 +1,651 @@
+defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
+  @moduledoc """
+  Git repository web view components.
+
+  These components are plain Phoenix components for repository overview,
+  navigation, trees, blobs, diffs, and clone instructions. They accept already
+  loaded Git data and use slots for callers that need to provide Phoenix links
+  or custom actions.
+  """
+  use Phoenix.Component
+
+  import PhoenixDuskmoon.Component.Icon.Icons
+
+  @doc """
+  Renders a repository header with identity, visibility, default ref, metadata,
+  description, and actions.
+
+  ## Examples
+
+      <.dm_git_repository_header owner="duskmoon-dev" name="phoenix-duskmoon-ui" visibility="public">
+        <:meta>Updated 2 minutes ago</:meta>
+        <:action><.dm_link href="/settings">Settings</.dm_link></:action>
+      </.dm_git_repository_header>
+
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:owner, :string, default: nil, doc: "repository owner or namespace")
+  attr(:name, :string, required: true, doc: "repository name")
+  attr(:visibility, :string, default: nil, doc: "repository visibility label")
+  attr(:default_ref, :string, default: nil, doc: "default branch or ref name")
+  attr(:description, :string, default: nil, doc: "repository description")
+  attr(:rest, :global)
+
+  slot(:meta, doc: "metadata items displayed below the title") do
+    attr(:icon, :string, doc: "Material Design icon name")
+    attr(:class, :any, doc: "metadata item CSS classes")
+  end
+
+  slot(:action, doc: "header action controls") do
+    attr(:class, :any, doc: "action wrapper CSS classes")
+  end
+
+  def dm_git_repository_header(assigns) do
+    ~H"""
+    <section
+      id={@id}
+      class={[
+        "rounded-lg border border-surface-container-high bg-surface-container-low p-4",
+        @class
+      ]}
+      {@rest}
+    >
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="min-w-0 space-y-2">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <.dm_mdi name="source-repository" class="h-5 w-5 shrink-0 text-on-surface-variant" />
+            <h1 class="min-w-0 break-all text-xl font-semibold leading-7 text-on-surface">
+              <span :if={@owner not in [nil, ""]} class="font-normal text-on-surface-variant">
+                {@owner}/
+              </span>{@name}
+            </h1>
+            <span
+              :if={@visibility not in [nil, ""]}
+              class={[
+                "inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+                visibility_class(@visibility)
+              ]}
+            >
+              {@visibility}
+            </span>
+            <span
+              :if={@default_ref not in [nil, ""]}
+              class="inline-flex min-w-0 items-center gap-1 rounded-md border border-surface-container-high px-2 py-0.5 text-xs text-on-surface-variant"
+            >
+              <.dm_mdi name="source-branch" class="h-3.5 w-3.5 shrink-0" />
+              <span class="min-w-0 break-all">{@default_ref}</span>
+            </span>
+          </div>
+          <p
+            :if={@description not in [nil, ""]}
+            class="max-w-5xl break-words text-sm leading-6 text-on-surface-variant"
+          >
+            {@description}
+          </p>
+          <div :if={@meta != []} class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-on-surface-variant">
+            <span :for={item <- @meta} class={["inline-flex min-w-0 items-center gap-1.5", item[:class]]}>
+              <.dm_mdi :if={item[:icon]} name={item[:icon]} class="h-4 w-4 shrink-0" />
+              <span class="min-w-0 break-words">{render_slot(item)}</span>
+            </span>
+          </div>
+        </div>
+        <div :if={@action != []} class="flex shrink-0 flex-wrap items-center gap-2 md:justify-end">
+          <span :for={action <- @action} class={action[:class]}>
+            {render_slot(action)}
+          </span>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  @doc """
+  Renders repository route navigation for server-rendered pages.
+
+  Items accept `href`, `navigate`, or `patch`, so the caller can use normal
+  Phoenix route values without a client-side tab panel.
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:label, :string, default: "Repository navigation", doc: "navigation aria-label")
+  attr(:rest, :global)
+
+  slot(:item, required: true, doc: "repository navigation items") do
+    attr(:label, :string, doc: "item label when no slot content is provided")
+    attr(:href, :any, doc: "regular browser href")
+    attr(:navigate, :string, doc: "LiveView navigate destination")
+    attr(:patch, :string, doc: "LiveView patch destination")
+    attr(:replace, :boolean, doc: "replace browser history for LiveView links")
+    attr(:active, :boolean, doc: "mark item as current page")
+    attr(:icon, :string, doc: "Material Design icon name")
+    attr(:count, :any, doc: "optional count badge")
+    attr(:class, :any, doc: "item CSS classes")
+  end
+
+  def dm_git_repository_nav(assigns) do
+    ~H"""
+    <nav id={@id} class={["border-b border-surface-container-high", @class]} aria-label={@label} {@rest}>
+      <ul role="list" class="flex min-w-0 gap-1 overflow-x-auto">
+        <li :for={item <- @item} class="shrink-0">
+          <a
+            href={link_href(item)}
+            data-phx-link={link_kind(item)}
+            data-phx-link-state={link_state(item)}
+            class={[
+              "inline-flex h-10 items-center gap-2 border-b-2 px-3 text-sm font-medium transition-colors",
+              item[:active] && "border-primary text-primary",
+              !item[:active] && "border-transparent text-on-surface-variant hover:text-on-surface",
+              item[:class]
+            ]}
+            aria-current={item[:active] && "page"}
+          >
+            <.dm_mdi :if={item[:icon]} name={item[:icon]} class="h-4 w-4 shrink-0" />
+            <span class="whitespace-nowrap">
+              <%= if item[:inner_block] do %>
+                {render_slot(item)}
+              <% else %>
+                {item[:label]}
+              <% end %>
+            </span>
+            <span
+              :if={item[:count] not in [nil, ""]}
+              class="rounded-full bg-surface-container-high px-1.5 py-0.5 text-xs text-on-surface-variant"
+            >
+              {item[:count]}
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+    """
+  end
+
+  @doc """
+  Renders a dense repository file tree.
+
+  Each row can be a folder, file, submodule, symlink, or any custom kind. Rows
+  accept `href`, `navigate`, or `patch` for server-rendered repository routes.
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:label, :string, default: "Repository files", doc: "file tree aria-label")
+
+  attr(:empty_message, :string,
+    default: "This repository is empty.",
+    doc: "message for empty trees"
+  )
+
+  attr(:rest, :global)
+
+  slot(:row, doc: "file tree rows") do
+    attr(:kind, :any, doc: "entry kind: folder, file, submodule, symlink, or custom")
+    attr(:name, :string, doc: "entry display name")
+    attr(:path, :string, doc: "entry path or secondary metadata")
+    attr(:meta, :string, doc: "right-side metadata such as size, mode, or object id")
+    attr(:href, :any, doc: "regular browser href")
+    attr(:navigate, :string, doc: "LiveView navigate destination")
+    attr(:patch, :string, doc: "LiveView patch destination")
+    attr(:replace, :boolean, doc: "replace browser history for LiveView links")
+    attr(:active, :boolean, doc: "mark item as selected")
+    attr(:class, :any, doc: "row CSS classes")
+    attr(:aria_label, :string, doc: "custom row aria-label")
+  end
+
+  def dm_git_file_tree(assigns) do
+    ~H"""
+    <section
+      id={@id}
+      class={[
+        "overflow-hidden rounded-lg border border-surface-container-high bg-surface-container-low",
+        @class
+      ]}
+      aria-label={@label}
+      {@rest}
+    >
+      <ul :if={@row != []} role="list" class="divide-y divide-surface-container-high">
+        <li :for={row <- @row}>
+          <.git_tree_entry row={row} />
+        </li>
+      </ul>
+      <div :if={@row == []} class="px-4 py-8 text-center text-sm text-on-surface-variant">
+        {@empty_message}
+      </div>
+    </section>
+    """
+  end
+
+  attr(:row, :map, required: true)
+
+  defp git_tree_entry(assigns) do
+    ~H"""
+    <a
+      :if={has_link?(@row)}
+      href={link_href(@row)}
+      data-phx-link={link_kind(@row)}
+      data-phx-link-state={link_state(@row)}
+      class={tree_row_class(@row)}
+      aria-current={@row[:active] && "true"}
+      aria-label={@row[:aria_label] || tree_row_label(@row)}
+    >
+      <.git_tree_entry_content row={@row} />
+    </a>
+    <div
+      :if={!has_link?(@row)}
+      class={tree_row_class(@row)}
+      aria-current={@row[:active] && "true"}
+      aria-label={@row[:aria_label] || tree_row_label(@row)}
+    >
+      <.git_tree_entry_content row={@row} />
+    </div>
+    """
+  end
+
+  attr(:row, :map, required: true)
+
+  defp git_tree_entry_content(assigns) do
+    ~H"""
+    <.dm_mdi name={tree_icon(@row[:kind])} class={["h-5 w-5 shrink-0", tree_icon_class(@row[:kind])]} />
+    <span class="min-w-0 flex-1">
+      <span class="block min-w-0 break-all font-medium text-on-surface">
+        {@row[:name] || render_slot(@row)}
+      </span>
+      <span :if={@row[:path] not in [nil, ""]} class="block min-w-0 break-all text-xs text-on-surface-variant">
+        {@row[:path]}
+      </span>
+    </span>
+    <span :if={@row[:meta] not in [nil, ""]} class="shrink-0 text-xs text-on-surface-variant">
+      {@row[:meta]}
+    </span>
+    """
+  end
+
+  @doc """
+  Renders a read-only repository blob panel.
+
+  Supports raw/copy action affordances plus truncated, binary, and non-UTF-8
+  states.
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:filename, :string, required: true, doc: "blob filename")
+  attr(:size, :string, default: nil, doc: "human-readable blob size")
+  attr(:language, :string, default: nil, doc: "syntax language hint")
+  attr(:content, :string, default: "", doc: "blob text content")
+  attr(:raw_href, :any, default: nil, doc: "raw file URL")
+  attr(:truncated, :boolean, default: false, doc: "mark content as truncated")
+  attr(:binary, :boolean, default: false, doc: "mark blob as binary")
+  attr(:non_utf8, :boolean, default: false, doc: "mark blob as non-UTF-8 text")
+  attr(:copy_label, :string, default: "Copy file contents", doc: "copy button aria-label")
+  attr(:raw_label, :string, default: "View raw file", doc: "raw link aria-label")
+  attr(:rest, :global)
+
+  slot(:action, doc: "additional blob actions") do
+    attr(:class, :any, doc: "action wrapper CSS classes")
+  end
+
+  def dm_git_blob_viewer(assigns) do
+    ~H"""
+    <section
+      id={@id}
+      class={[
+        "overflow-hidden rounded-lg border border-surface-container-high bg-surface-container-low",
+        @class
+      ]}
+      {@rest}
+    >
+      <div class="flex flex-col gap-3 border-b border-surface-container-high px-4 py-3 md:flex-row md:items-center md:justify-between">
+        <div class="min-w-0">
+          <h2 class="min-w-0 break-all text-sm font-semibold text-on-surface">{@filename}</h2>
+          <p :if={@size not in [nil, ""]} class="text-xs text-on-surface-variant">{@size}</p>
+        </div>
+        <div class="flex shrink-0 flex-wrap items-center gap-2">
+          <a
+            :if={@raw_href}
+            href={@raw_href}
+            class="btn btn-sm"
+            aria-label={@raw_label}
+          >
+            Raw
+          </a>
+          <button
+            :if={!@binary && !@non_utf8}
+            type="button"
+            class="btn btn-sm"
+            aria-label={@copy_label}
+            data-copy-value={@content}
+          >
+            Copy
+          </button>
+          <span :for={action <- @action} class={action[:class]}>
+            {render_slot(action)}
+          </span>
+        </div>
+      </div>
+      <p :if={@truncated} class="border-b border-warning px-4 py-2 text-sm text-warning">
+        This file is truncated.
+      </p>
+      <p :if={@binary} class="px-4 py-8 text-center text-sm text-on-surface-variant">
+        Binary file not shown.
+      </p>
+      <p :if={!@binary && @non_utf8} class="px-4 py-8 text-center text-sm text-on-surface-variant">
+        Non-UTF-8 file not shown.
+      </p>
+      <pre
+        :if={!@binary && !@non_utf8}
+        class="overflow-x-auto p-4 text-sm leading-6"
+        data-language={@language}
+      ><code class="block min-w-max whitespace-pre font-mono">{@content}</code></pre>
+    </section>
+    """
+  end
+
+  @doc """
+  Renders commit metadata and a unified diff presentation.
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:title, :string, required: true, doc: "commit title")
+  attr(:sha, :string, default: nil, doc: "commit SHA")
+  attr(:author, :string, default: nil, doc: "commit author")
+  attr(:committed_at, :string, default: nil, doc: "commit timestamp")
+  attr(:message, :string, default: nil, doc: "commit body")
+  attr(:changed_files, :integer, default: nil, doc: "changed file count")
+  attr(:additions, :integer, default: nil, doc: "total added lines")
+  attr(:deletions, :integer, default: nil, doc: "total deleted lines")
+  attr(:rest, :global)
+
+  slot(:file, doc: "changed file diff sections") do
+    attr(:path, :string, doc: "changed file path")
+    attr(:status, :string, doc: "file status label")
+    attr(:additions, :integer, doc: "file added line count")
+    attr(:deletions, :integer, doc: "file deleted line count")
+    attr(:binary, :boolean, doc: "mark file diff as binary")
+    attr(:truncated, :boolean, doc: "mark file diff as truncated")
+    attr(:lines, :list, doc: "diff line maps with type, old_line, new_line, and content")
+    attr(:class, :any, doc: "file section CSS classes")
+  end
+
+  def dm_git_commit_diff(assigns) do
+    ~H"""
+    <section
+      id={@id}
+      class={[
+        "overflow-hidden rounded-lg border border-surface-container-high bg-surface-container-low",
+        @class
+      ]}
+      {@rest}
+    >
+      <header class="space-y-3 border-b border-surface-container-high px-4 py-3">
+        <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+          <div class="min-w-0">
+            <h2 class="break-words text-base font-semibold leading-6 text-on-surface">{@title}</h2>
+            <p :if={@message not in [nil, ""]} class="mt-1 whitespace-pre-wrap break-words text-sm text-on-surface-variant">
+              {@message}
+            </p>
+          </div>
+          <code :if={@sha not in [nil, ""]} class="shrink-0 rounded bg-surface-container-high px-2 py-1 font-mono text-xs text-on-surface-variant">
+            {short_sha(@sha)}
+          </code>
+        </div>
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-on-surface-variant">
+          <span :if={@author not in [nil, ""]} class="inline-flex items-center gap-1">
+            <.dm_mdi name="account" class="h-4 w-4" /> {@author}
+          </span>
+          <span :if={@committed_at not in [nil, ""]} class="inline-flex items-center gap-1">
+            <.dm_mdi name="clock-outline" class="h-4 w-4" /> {@committed_at}
+          </span>
+          <span :if={has_stats?(@changed_files, @additions, @deletions)} class="inline-flex items-center gap-2">
+            <span :if={@changed_files}>{changed_files_label(@changed_files)}</span>
+            <span :if={@additions} class="text-success">+{@additions}</span>
+            <span :if={@deletions} class="text-error">-{@deletions}</span>
+          </span>
+        </div>
+      </header>
+      <div :if={@file != []} class="divide-y divide-surface-container-high">
+        <section :for={file <- @file} class={["bg-surface", file[:class]]}>
+          <header class="flex flex-col gap-2 bg-surface-container px-4 py-2 text-sm md:flex-row md:items-center md:justify-between">
+            <div class="flex min-w-0 items-center gap-2">
+              <span class="rounded border border-surface-container-high px-1.5 py-0.5 text-xs uppercase text-on-surface-variant">
+                {file[:status] || "modified"}
+              </span>
+              <span class="min-w-0 break-all font-medium text-on-surface">{file[:path]}</span>
+            </div>
+            <span class="shrink-0 text-xs">
+              <span :if={file[:additions]} class="text-success">+{file[:additions]}</span>
+              <span :if={file[:deletions]} class="ml-2 text-error">-{file[:deletions]}</span>
+            </span>
+          </header>
+          <p :if={file[:binary]} class="px-4 py-6 text-center text-sm text-on-surface-variant">
+            Binary file changed.
+          </p>
+          <p :if={file[:truncated]} class="border-b border-warning px-4 py-2 text-sm text-warning">
+            Diff truncated.
+          </p>
+          <div :if={!file[:binary] && file_lines(file) != []} class="overflow-x-auto font-mono text-sm leading-6">
+            <div
+              :for={line <- file_lines(file)}
+              class={[
+                "grid min-w-max grid-cols-[4rem_4rem_1.5rem_1fr]",
+                diff_line_class(line[:type])
+              ]}
+            >
+              <span class="select-none px-2 text-right text-on-surface-variant">{line[:old_line]}</span>
+              <span class="select-none px-2 text-right text-on-surface-variant">{line[:new_line]}</span>
+              <span class="select-none px-1 text-center">{diff_marker(line[:type])}</span>
+              <code class="whitespace-pre pr-4">{line[:content]}</code>
+            </div>
+          </div>
+          <div :if={!file[:binary] && file_lines(file) == [] && file[:inner_block]} class="overflow-x-auto">
+            {render_slot(file)}
+          </div>
+        </section>
+      </div>
+      <div :if={@file == []} class="px-4 py-8 text-center text-sm text-on-surface-variant">
+        No file changes.
+      </div>
+    </section>
+    """
+  end
+
+  @doc """
+  Renders clone URLs and copyable command snippets.
+
+  Use command slots for empty repository setup instructions such as adding a
+  remote and pushing the first branch.
+  """
+  @doc type: :component
+  attr(:id, :any, default: nil, doc: "HTML id attribute")
+  attr(:class, :any, default: nil, doc: "additional CSS classes")
+  attr(:title, :string, default: "Clone repository", doc: "panel title")
+  attr(:clone_url, :string, default: nil, doc: "default HTTPS clone URL")
+  attr(:ssh_url, :string, default: nil, doc: "SSH clone URL")
+  attr(:empty, :boolean, default: false, doc: "render empty repository defaults")
+  attr(:rest, :global)
+
+  slot(:url, doc: "clone URL rows") do
+    attr(:label, :string, doc: "URL label")
+    attr(:value, :string, doc: "clone URL value")
+    attr(:active, :boolean, doc: "mark URL as active")
+    attr(:class, :any, doc: "URL row CSS classes")
+  end
+
+  slot(:command, doc: "command rows") do
+    attr(:label, :string, doc: "command label")
+    attr(:value, :string, doc: "command value")
+    attr(:class, :any, doc: "command row CSS classes")
+  end
+
+  def dm_git_clone_box(assigns) do
+    assigns =
+      assigns
+      |> assign(:default_urls, default_clone_urls(assigns))
+      |> assign(:default_commands, default_clone_commands(assigns))
+
+    ~H"""
+    <section
+      id={@id}
+      class={[
+        "space-y-4 rounded-lg border border-surface-container-high bg-surface-container-low p-4",
+        @class
+      ]}
+      {@rest}
+    >
+      <h2 class="text-sm font-semibold text-on-surface">{@title}</h2>
+      <div :if={@url != [] || @default_urls != []} class="space-y-2">
+        <div :for={url <- @url} class={["flex min-w-0 items-center gap-2", url[:class]]}>
+          <span class="w-16 shrink-0 text-xs font-medium uppercase text-on-surface-variant">
+            {url[:label] || "URL"}
+          </span>
+          <code class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container px-2 py-1 font-mono text-sm">
+            {url[:value]}
+          </code>
+          <button type="button" class="btn btn-sm" aria-label={"Copy #{url[:label] || "URL"}"} data-copy-value={url[:value]}>
+            Copy
+          </button>
+        </div>
+        <div :for={url <- @default_urls} class="flex min-w-0 items-center gap-2">
+          <span class="w-16 shrink-0 text-xs font-medium uppercase text-on-surface-variant">
+            {url.label}
+          </span>
+          <code class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container px-2 py-1 font-mono text-sm">
+            {url.value}
+          </code>
+          <button type="button" class="btn btn-sm" aria-label={"Copy #{url.label}"} data-copy-value={url.value}>
+            Copy
+          </button>
+        </div>
+      </div>
+      <div :if={@command != [] || @default_commands != []} class="space-y-2">
+        <div :for={command <- @command} class={command[:class]}>
+          <div class="mb-1 text-xs font-medium uppercase text-on-surface-variant">
+            {command[:label] || "Command"}
+          </div>
+          <div class="flex min-w-0 items-start gap-2">
+            <pre class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container p-3 text-sm"><code class="font-mono">{command[:value]}</code></pre>
+            <button type="button" class="btn btn-sm" aria-label={"Copy #{command[:label] || "command"}"} data-copy-value={command[:value]}>
+              Copy
+            </button>
+          </div>
+        </div>
+        <div :for={command <- @default_commands}>
+          <div class="mb-1 text-xs font-medium uppercase text-on-surface-variant">
+            {command.label}
+          </div>
+          <div class="flex min-w-0 items-start gap-2">
+            <pre class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container p-3 text-sm"><code class="font-mono">{command.value}</code></pre>
+            <button type="button" class="btn btn-sm" aria-label={"Copy #{command.label}"} data-copy-value={command.value}>
+              Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  defp visibility_class("private"), do: "border-warning text-warning"
+  defp visibility_class("internal"), do: "border-info text-info"
+  defp visibility_class(_visibility), do: "border-surface-container-high text-on-surface-variant"
+
+  defp link_href(item), do: item[:href] || item[:navigate] || item[:patch] || "#"
+
+  defp link_kind(item) do
+    cond do
+      item[:navigate] not in [nil, ""] -> "redirect"
+      item[:patch] not in [nil, ""] -> "patch"
+      true -> nil
+    end
+  end
+
+  defp link_state(item) do
+    if link_kind(item), do: if(item[:replace], do: "replace", else: "push")
+  end
+
+  defp has_link?(item), do: link_href(item) != "#"
+
+  defp tree_row_class(row) do
+    [
+      "flex min-w-0 items-center gap-3 px-4 py-2 text-sm transition-colors",
+      has_link?(row) && "hover:bg-surface-container",
+      row[:active] && "bg-surface-container text-primary",
+      row[:class]
+    ]
+  end
+
+  defp tree_row_label(row) do
+    [row[:kind] || "file", row[:name] || "entry"]
+    |> Enum.map_join(" ", &to_string/1)
+  end
+
+  defp tree_icon(kind) when kind in [:folder, "folder", :dir, "dir"], do: "folder"
+  defp tree_icon(kind) when kind in [:submodule, "submodule"], do: "source-repository"
+  defp tree_icon(kind) when kind in [:symlink, "symlink"], do: "file-link-outline"
+  defp tree_icon(_kind), do: "file-document-outline"
+
+  defp tree_icon_class(kind) when kind in [:folder, "folder", :dir, "dir"], do: "text-warning"
+  defp tree_icon_class(kind) when kind in [:submodule, "submodule"], do: "text-info"
+  defp tree_icon_class(_kind), do: "text-on-surface-variant"
+
+  defp short_sha(sha) when is_binary(sha) and byte_size(sha) > 12, do: binary_part(sha, 0, 12)
+  defp short_sha(sha), do: sha
+
+  defp has_stats?(changed_files, additions, deletions) do
+    changed_files not in [nil, ""] || additions not in [nil, ""] || deletions not in [nil, ""]
+  end
+
+  defp changed_files_label(1), do: "1 file"
+  defp changed_files_label(count), do: "#{count} files"
+
+  defp file_lines(file), do: file[:lines] || []
+
+  defp diff_line_class(type) when type in [:add, "add", :added, "added"],
+    do: "bg-success/10 text-success"
+
+  defp diff_line_class(type) when type in [:delete, "delete", :del, "del", :deleted, "deleted"],
+    do: "bg-error/10 text-error"
+
+  defp diff_line_class(type) when type in [:hunk, "hunk"], do: "bg-info/10 text-info"
+  defp diff_line_class(_type), do: "text-on-surface"
+
+  defp diff_marker(type) when type in [:add, "add", :added, "added"], do: "+"
+
+  defp diff_marker(type) when type in [:delete, "delete", :del, "del", :deleted, "deleted"],
+    do: "-"
+
+  defp diff_marker(type) when type in [:hunk, "hunk"], do: "@"
+  defp diff_marker(_type), do: " "
+
+  defp default_clone_urls(%{url: [_ | _]}), do: []
+
+  defp default_clone_urls(assigns) do
+    [
+      clone_url(assigns[:clone_url], "HTTPS"),
+      clone_url(assigns[:ssh_url], "SSH")
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp clone_url(nil, _label), do: nil
+  defp clone_url("", _label), do: nil
+  defp clone_url(value, label), do: %{label: label, value: value}
+
+  defp default_clone_commands(%{command: [_ | _]}), do: []
+
+  defp default_clone_commands(%{clone_url: value, empty: false}) when value not in [nil, ""],
+    do: [%{label: "Clone", value: "git clone #{value}"}]
+
+  defp default_clone_commands(%{clone_url: value, empty: true}) when value not in [nil, ""] do
+    [
+      %{label: "Add remote", value: "git remote add origin #{value}"},
+      %{label: "Push", value: "git push -u origin main"}
+    ]
+  end
+
+  defp default_clone_commands(_assigns), do: []
+end

--- a/apps/phoenix_duskmoon/mix.exs
+++ b/apps/phoenix_duskmoon/mix.exs
@@ -51,6 +51,7 @@ defmodule PhoenixDuskmoon.Mixfile do
             PhoenixDuskmoon.Component.DataDisplay.Chip,
             PhoenixDuskmoon.Component.DataDisplay.Collapse,
             PhoenixDuskmoon.Component.DataDisplay.Flash,
+            PhoenixDuskmoon.Component.DataDisplay.GitRepository,
             PhoenixDuskmoon.Component.DataDisplay.List,
             PhoenixDuskmoon.Component.DataDisplay.Markdown,
             PhoenixDuskmoon.Component.DataDisplay.Pagination,

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/git_repository_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/git_repository_test.exs
@@ -1,0 +1,238 @@
+defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepositoryTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+  import PhoenixDuskmoon.Component.DataDisplay.GitRepository
+
+  describe "dm_git_repository_header/1" do
+    test "renders repository identity, metadata, and actions" do
+      result =
+        render_component(&dm_git_repository_header/1, %{
+          id: "repo-header",
+          owner: "duskmoon-dev",
+          name: "phoenix-duskmoon-ui",
+          visibility: "public",
+          default_ref: "main",
+          description: "DuskMoon UI for Phoenix",
+          meta: [
+            %{icon: "source-commit", inner_block: fn _, _ -> "b91d64a" end}
+          ],
+          action: [
+            %{inner_block: fn _, _ -> "Settings" end}
+          ]
+        })
+
+      assert result =~ ~s(id="repo-header")
+      assert result =~ "duskmoon-dev/"
+      assert result =~ "phoenix-duskmoon-ui"
+      assert result =~ "public"
+      assert result =~ "main"
+      assert result =~ "DuskMoon UI for Phoenix"
+      assert result =~ "b91d64a"
+      assert result =~ "Settings"
+    end
+  end
+
+  describe "dm_git_repository_nav/1" do
+    test "renders href, navigate, patch, active, and count items" do
+      result =
+        render_component(&dm_git_repository_nav/1, %{
+          item: [
+            %{label: "Code", href: "/repos/demo", icon: "code-tags", active: true},
+            %{label: "Commits", navigate: "/repos/demo/commits", replace: true, count: 12},
+            %{label: "Branches", patch: "/repos/demo?tab=branches"}
+          ]
+        })
+
+      assert result =~ ~s[href="/repos/demo"]
+      assert result =~ ~s[aria-current="page"]
+      assert result =~ "Code"
+      assert result =~ ~s[href="/repos/demo/commits"]
+      assert result =~ ~s[data-phx-link="redirect"]
+      assert result =~ ~s[data-phx-link-state="replace"]
+      assert result =~ "12"
+      assert result =~ ~s[href="/repos/demo?tab=branches"]
+      assert result =~ ~s[data-phx-link="patch"]
+    end
+  end
+
+  describe "dm_git_file_tree/1" do
+    test "renders linked repository rows with kinds, metadata, and selection state" do
+      result =
+        render_component(&dm_git_file_tree/1, %{
+          row: [
+            %{kind: "folder", name: "lib", path: "lib", href: "/tree/lib", meta: "12 files"},
+            %{
+              kind: "file",
+              name: "mix.exs",
+              path: "mix.exs",
+              patch: "/blob/mix.exs",
+              active: true,
+              meta: "4 KB"
+            },
+            %{kind: "submodule", name: "vendor/theme", path: "vendor/theme", meta: "a13f9c2"}
+          ]
+        })
+
+      assert result =~ "lib"
+      assert result =~ "12 files"
+      assert result =~ ~s[href="/tree/lib"]
+      assert result =~ "mix.exs"
+      assert result =~ ~s[data-phx-link="patch"]
+      assert result =~ ~s[aria-current="true"]
+      assert result =~ "vendor/theme"
+      assert result =~ "a13f9c2"
+    end
+
+    test "renders empty state" do
+      result =
+        render_component(&dm_git_file_tree/1, %{
+          empty_message: "No files on this branch."
+        })
+
+      assert result =~ "No files on this branch."
+    end
+  end
+
+  describe "dm_git_blob_viewer/1" do
+    test "renders source content, raw link, and copy affordance" do
+      result =
+        render_component(&dm_git_blob_viewer/1, %{
+          filename: "lib/app.ex",
+          size: "128 B",
+          language: "elixir",
+          content: "defmodule App do\nend\n",
+          raw_href: "/raw/lib/app.ex"
+        })
+
+      assert result =~ "lib/app.ex"
+      assert result =~ "128 B"
+      assert result =~ ~s[data-language="elixir"]
+      assert result =~ "defmodule App"
+      assert result =~ ~s[href="/raw/lib/app.ex"]
+      assert result =~ "data-copy-value"
+    end
+
+    test "renders truncated, binary, and non-UTF-8 states" do
+      truncated =
+        render_component(&dm_git_blob_viewer/1, %{
+          filename: "README.md",
+          content: "# README",
+          truncated: true
+        })
+
+      binary =
+        render_component(&dm_git_blob_viewer/1, %{
+          filename: "logo.png",
+          binary: true
+        })
+
+      non_utf8 =
+        render_component(&dm_git_blob_viewer/1, %{
+          filename: "legacy.txt",
+          non_utf8: true
+        })
+
+      assert truncated =~ "This file is truncated."
+      assert binary =~ "Binary file not shown."
+      refute binary =~ "<pre"
+      assert non_utf8 =~ "Non-UTF-8 file not shown."
+      refute non_utf8 =~ "<pre"
+    end
+  end
+
+  describe "dm_git_commit_diff/1" do
+    test "renders commit metadata, changed-file summary, and diff lines" do
+      result =
+        render_component(&dm_git_commit_diff/1, %{
+          title: "Add forge components",
+          sha: "b91d64a5f5a2c7e6d9a6",
+          author: "Jonathan",
+          committed_at: "2 minutes ago",
+          message: "Render repository data without client tabs.",
+          changed_files: 1,
+          additions: 2,
+          deletions: 1,
+          file: [
+            %{
+              path: "lib/repo_view.ex",
+              status: "modified",
+              additions: 2,
+              deletions: 1,
+              lines: [
+                %{type: :hunk, old_line: nil, new_line: nil, content: "@@ -1,3 +1,4 @@"},
+                %{type: :context, old_line: 1, new_line: 1, content: "defmodule RepoView do"},
+                %{type: :delete, old_line: 2, new_line: nil, content: "  def old, do: :ok"},
+                %{type: :add, old_line: nil, new_line: 2, content: "  def new, do: :ok"}
+              ]
+            }
+          ]
+        })
+
+      assert result =~ "Add forge components"
+      assert result =~ "b91d64a5f5a"
+      assert result =~ "Jonathan"
+      assert result =~ "2 minutes ago"
+      assert result =~ "Render repository data without client tabs."
+      assert result =~ "1 file"
+      assert result =~ "+2"
+      assert result =~ "-1"
+      assert result =~ "lib/repo_view.ex"
+      assert result =~ "@@ -1,3 +1,4 @@"
+      assert result =~ "def new, do: :ok"
+    end
+
+    test "renders binary, truncated, and empty diff states" do
+      result =
+        render_component(&dm_git_commit_diff/1, %{
+          title: "Update assets",
+          file: [
+            %{path: "logo.png", binary: true},
+            %{path: "large.diff", truncated: true}
+          ]
+        })
+
+      empty = render_component(&dm_git_commit_diff/1, %{title: "No changes"})
+
+      assert result =~ "Binary file changed."
+      assert result =~ "Diff truncated."
+      assert empty =~ "No file changes."
+    end
+  end
+
+  describe "dm_git_clone_box/1" do
+    test "renders default clone URLs and clone command" do
+      result =
+        render_component(&dm_git_clone_box/1, %{
+          clone_url: "https://github.com/example/repo.git",
+          ssh_url: "git@github.com:example/repo.git"
+        })
+
+      assert result =~ "HTTPS"
+      assert result =~ "https://github.com/example/repo.git"
+      assert result =~ "SSH"
+      assert result =~ "git@github.com:example/repo.git"
+      assert result =~ "git clone https://github.com/example/repo.git"
+    end
+
+    test "renders empty repository setup commands and custom command slots" do
+      empty =
+        render_component(&dm_git_clone_box/1, %{
+          clone_url: "https://github.com/example/empty.git",
+          empty: true
+        })
+
+      custom =
+        render_component(&dm_git_clone_box/1, %{
+          command: [
+            %{label: "Push existing", value: "git push -u origin main"}
+          ]
+        })
+
+      assert empty =~ "git remote add origin https://github.com/example/empty.git"
+      assert empty =~ "git push -u origin main"
+      assert custom =~ "Push existing"
+      assert custom =~ "git push -u origin main"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add slot-driven Git repository header, nav, file tree, blob, commit diff, and clone box components
- wire the components into the public PhoenixDuskmoon import path and ExDoc grouping
- add Storybook examples and focused render tests for repository web view states

## Tests
- mix test apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/git_repository_test.exs
- mix format --check-formatted
- mix compile --warnings-as-errors

Fixes #78