### PR TITLE
fix: enable git repository copy controls

### DIFF
--- a/apps/phoenix_duskmoon/assets/js/phoenix_duskmoon.js
+++ b/apps/phoenix_duskmoon/assets/js/phoenix_duskmoon.js
@@ -11,6 +11,11 @@ const DM_EVENTS = [
   "dm-submit", "dm-select", "dm-close", "dm-open", "dm-toggle",
 ];
 
+const COPY_SELECTOR = "[data-copy-value]";
+const COPY_FEEDBACK_DURATION = 2000;
+const COPY_LISTENER = Symbol.for("phoenix-duskmoon.copy-listener");
+const copyFeedback = new WeakMap();
+
 /**
  * WebComponentHook - Universal LiveView ↔ Custom Element bridge
  *
@@ -253,6 +258,108 @@ export const FormElementHook = {
     this._feedbackObserver.observe(form, { attributes: true, attributeFilter: ["class"] });
   },
 };
+
+/** Copy text with the Clipboard API, falling back only when it is unavailable. */
+export async function copyTextToClipboard(value, environment = globalThis) {
+  const clipboard = environment.navigator?.clipboard;
+
+  if (typeof clipboard?.writeText === "function") {
+    await clipboard.writeText(value);
+    return;
+  }
+
+  const document = environment.document;
+
+  if (!document?.body || typeof document.execCommand !== "function") {
+    throw new Error("Clipboard API is unavailable");
+  }
+
+  const textArea = document.createElement("textarea");
+  const activeElement = document.activeElement;
+  textArea.value = value;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+
+  try {
+    textArea.focus();
+    textArea.select();
+
+    if (!document.execCommand("copy")) {
+      throw new Error("Clipboard copy command failed");
+    }
+  } finally {
+    document.body.removeChild(textArea);
+    activeElement?.focus?.();
+  }
+}
+
+function copyStatus(button) {
+  const sibling = button.nextElementSibling;
+
+  if (sibling?.matches?.("[data-copy-status]")) {
+    return sibling;
+  }
+
+  return button.parentElement?.querySelector?.("[data-copy-status]") ?? null;
+}
+
+function showCopyFeedback(button, message, state, options) {
+  const label = button.querySelector?.("[data-copy-label]");
+  const status = copyStatus(button);
+  const previous = copyFeedback.get(button);
+  const cancelReset = options.cancelReset ?? globalThis.clearTimeout;
+  const scheduleReset = options.scheduleReset ?? globalThis.setTimeout;
+
+  if (previous?.timer !== undefined) {
+    cancelReset(previous.timer);
+  }
+
+  const originalLabel = previous?.originalLabel ?? label?.textContent ?? "Copy";
+
+  if (label) label.textContent = message;
+  if (status) status.textContent = message;
+  button.dataset.copyState = state;
+
+  const timer = scheduleReset(() => {
+    if (label) label.textContent = originalLabel;
+    if (status) status.textContent = "";
+    delete button.dataset.copyState;
+    copyFeedback.delete(button);
+  }, COPY_FEEDBACK_DURATION);
+
+  copyFeedback.set(button, { originalLabel, timer });
+}
+
+/** Handle clicks from any descendant of a generated copy control. */
+export async function handleClipboardClick(event, options = {}) {
+  const button = event.target?.closest?.(COPY_SELECTOR);
+
+  if (!button || button.disabled || button.getAttribute?.("aria-disabled") === "true") {
+    return;
+  }
+
+  const copy = options.copy ?? copyTextToClipboard;
+
+  try {
+    await copy(button.dataset.copyValue);
+    showCopyFeedback(button, button.dataset.copySuccess ?? "Copied", "success", options);
+  } catch (_error) {
+    showCopyFeedback(button, button.dataset.copyFailure ?? "Copy failed", "error", options);
+  }
+}
+
+/** Install one delegated listener so LiveView-patched copy controls also work. */
+export function installClipboardBehavior(root = globalThis.document, options = {}) {
+  if (!root?.addEventListener || root[COPY_LISTENER]) return;
+
+  const listener = (event) => handleClipboardClick(event, options);
+  root.addEventListener("click", listener);
+  root[COPY_LISTENER] = listener;
+}
+
+installClipboardBehavior();
 
 // Export to window for non-module usage
 if (typeof window !== "undefined") {

--- a/apps/phoenix_duskmoon/guides/hooks.md
+++ b/apps/phoenix_duskmoon/guides/hooks.md
@@ -18,6 +18,15 @@ let liveSocket = new LiveSocket("/live", Socket, {
 });
 ```
 
+Importing `phoenix_duskmoon/hooks` also loads the package runtime, including the
+delegated clipboard behavior used by the Git repository components. Apps that
+use those server-rendered components without LiveView hooks can load only that
+runtime:
+
+```javascript
+import "phoenix_duskmoon";
+```
+
 Or import individual hooks:
 
 ```javascript

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/git_repository.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/git_repository.ex
@@ -312,15 +312,11 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
           >
             Raw
           </a>
-          <button
+          <.git_copy_button
             :if={!@binary && !@non_utf8}
-            type="button"
-            class="btn btn-sm"
-            aria-label={@copy_label}
-            data-copy-value={@content}
-          >
-            Copy
-          </button>
+            label={@copy_label}
+            value={@content}
+          />
           <span :for={action <- @action} class={action[:class]}>
             {render_slot(action)}
           </span>
@@ -505,9 +501,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
           <code class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container px-2 py-1 font-mono text-sm">
             {url[:value]}
           </code>
-          <button type="button" class="btn btn-sm" aria-label={"Copy #{url[:label] || "URL"}"} data-copy-value={url[:value]}>
-            Copy
-          </button>
+          <.git_copy_button label={"Copy #{url[:label] || "URL"}"} value={url[:value]} />
         </div>
         <div :for={url <- @default_urls} class="flex min-w-0 items-center gap-2">
           <span class="w-16 shrink-0 text-xs font-medium uppercase text-on-surface-variant">
@@ -516,9 +510,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
           <code class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container px-2 py-1 font-mono text-sm">
             {url.value}
           </code>
-          <button type="button" class="btn btn-sm" aria-label={"Copy #{url.label}"} data-copy-value={url.value}>
-            Copy
-          </button>
+          <.git_copy_button label={"Copy #{url.label}"} value={url.value} />
         </div>
       </div>
       <div :if={@command != [] || @default_commands != []} class="space-y-2">
@@ -528,9 +520,10 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
           </div>
           <div class="flex min-w-0 items-start gap-2">
             <pre class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container p-3 text-sm"><code class="font-mono">{command[:value]}</code></pre>
-            <button type="button" class="btn btn-sm" aria-label={"Copy #{command[:label] || "command"}"} data-copy-value={command[:value]}>
-              Copy
-            </button>
+            <.git_copy_button
+              label={"Copy #{command[:label] || "command"}"}
+              value={command[:value]}
+            />
           </div>
         </div>
         <div :for={command <- @default_commands}>
@@ -539,13 +532,30 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepository do
           </div>
           <div class="flex min-w-0 items-start gap-2">
             <pre class="min-w-0 flex-1 overflow-x-auto rounded bg-surface-container p-3 text-sm"><code class="font-mono">{command.value}</code></pre>
-            <button type="button" class="btn btn-sm" aria-label={"Copy #{command.label}"} data-copy-value={command.value}>
-              Copy
-            </button>
+            <.git_copy_button label={"Copy #{command.label}"} value={command.value} />
           </div>
         </div>
       </div>
     </section>
+    """
+  end
+
+  attr(:label, :string, required: true)
+  attr(:value, :string, required: true)
+
+  defp git_copy_button(assigns) do
+    ~H"""
+    <button type="button" class="btn btn-sm" aria-label={@label} data-copy-value={@value}>
+      <span data-copy-label>Copy</span>
+    </button>
+    <span
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-copy-status
+    >
+    </span>
     """
   end
 

--- a/apps/phoenix_duskmoon/test/js/phoenix_duskmoon.test.js
+++ b/apps/phoenix_duskmoon/test/js/phoenix_duskmoon.test.js
@@ -1,0 +1,118 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+	copyTextToClipboard,
+	installClipboardBehavior,
+} from "../../assets/js/phoenix_duskmoon.js";
+
+function copyControl(value) {
+	const label = { textContent: "Copy" };
+	const status = {
+		textContent: "",
+		matches: (selector) => selector === "[data-copy-status]",
+	};
+	const button = {
+		dataset: { copyValue: value },
+		disabled: false,
+		getAttribute: () => null,
+		nextElementSibling: status,
+		querySelector: (selector) =>
+			selector === "[data-copy-label]" ? label : null,
+	};
+	const target = {
+		closest: (selector) => (selector === "[data-copy-value]" ? button : null),
+	};
+
+	return { button, label, status, target };
+}
+
+function delegatedRoot() {
+	const listeners = new Map();
+
+	return {
+		addEventListener: mock((event, listener) => listeners.set(event, listener)),
+		listeners,
+	};
+}
+
+const noReset = () => undefined;
+
+describe("delegated clipboard behavior", () => {
+	test("copies the exact value and announces success", async () => {
+		const root = delegatedRoot();
+		const control = copyControl(
+			"git clone https://example.test/acme/demo.git\n",
+		);
+		const copy = mock(async () => undefined);
+
+		installClipboardBehavior(root, { copy, scheduleReset: noReset });
+		await root.listeners.get("click")({ target: control.target });
+
+		expect(copy).toHaveBeenCalledWith(
+			"git clone https://example.test/acme/demo.git\n",
+		);
+		expect(control.label.textContent).toBe("Copied");
+		expect(control.status.textContent).toBe("Copied");
+		expect(control.button.dataset.copyState).toBe("success");
+	});
+
+	test("announces clipboard failures without moving focus", async () => {
+		const root = delegatedRoot();
+		const control = copyControl("blob contents");
+		const copy = mock(async () => {
+			throw new Error("permission denied");
+		});
+
+		installClipboardBehavior(root, { copy, scheduleReset: noReset });
+		await root.listeners.get("click")({ target: control.target });
+
+		expect(control.label.textContent).toBe("Copy failed");
+		expect(control.status.textContent).toBe("Copy failed");
+		expect(control.button.dataset.copyState).toBe("error");
+	});
+
+	test("uses the legacy copy command only when the Clipboard API is unavailable", async () => {
+		const activeElement = { focus: mock(() => undefined) };
+		const textArea = {
+			focus: mock(() => undefined),
+			select: mock(() => undefined),
+			setAttribute: mock(() => undefined),
+			style: {},
+			value: "",
+		};
+		const body = {
+			appendChild: mock(() => undefined),
+			removeChild: mock(() => undefined),
+		};
+		const document = {
+			activeElement,
+			body,
+			createElement: mock(() => textArea),
+			execCommand: mock(() => true),
+		};
+
+		await copyTextToClipboard("fallback value", { document, navigator: {} });
+
+		expect(textArea.value).toBe("fallback value");
+		expect(document.execCommand).toHaveBeenCalledWith("copy");
+		expect(body.removeChild).toHaveBeenCalledWith(textArea);
+		expect(activeElement.focus).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not use the legacy command when the Clipboard API rejects", async () => {
+		const writeText = mock(async () => {
+			throw new Error("permission denied");
+		});
+		const document = { execCommand: mock(() => true) };
+
+		await expect(
+			copyTextToClipboard("protected value", {
+				document,
+				navigator: { clipboard: { writeText } },
+			}),
+		).rejects.toThrow("permission denied");
+
+		expect(writeText).toHaveBeenCalledWith("protected value");
+		expect(document.execCommand).not.toHaveBeenCalled();
+	});
+});

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/git_repository_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/git_repository_test.exs
@@ -111,6 +111,11 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepositoryTest do
       assert result =~ "defmodule App"
       assert result =~ ~s[href="/raw/lib/app.ex"]
       assert result =~ "data-copy-value"
+      assert result =~ "data-copy-label"
+      assert result =~ "data-copy-status"
+      assert result =~ ~s[role="status"]
+      assert result =~ ~s[aria-live="polite"]
+      assert result =~ ~s[aria-atomic="true"]
     end
 
     test "renders truncated, binary, and non-UTF-8 states" do
@@ -213,6 +218,8 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.GitRepositoryTest do
       assert result =~ "SSH"
       assert result =~ "git@github.com:example/repo.git"
       assert result =~ "git clone https://github.com/example/repo.git"
+      assert [_, _, _] = Regex.scan(~r/data-copy-value=/, result)
+      assert [_, _, _] = Regex.scan(~r/data-copy-status/, result)
     end
 
     test "renders empty repository setup commands and custom command slots" do


### PR DESCRIPTION
## Summary
- add delegated clipboard handling for blob, clone URL, and command copy controls
- provide visible and screen-reader success or failure feedback with focus-safe fallback copying
- add runtime and component tests plus package import guidance

## Validation
- mix format --check-formatted
- DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix compile --warnings-as-errors
- MIX_ENV=test DUSKMOON_BUILD_NATIVE_FROM_SOURCE=1 mix test
- bun test apps/phoenix_duskmoon/test/js/phoenix_duskmoon.test.js
- mix duskmoon_bundler.build phoenix_duskmoon

Fixes #80