### PR TITLE
fix: support Tailwind CSS 4.3.3

### DIFF
--- a/apps/phoenix_duskmoon/package.json
+++ b/apps/phoenix_duskmoon/package.json
@@ -46,6 +46,6 @@
     "postcss": "8.5.19"
   },
   "peerDependencies": {
-    "tailwindcss": "4.3.3"
+    "tailwindcss": "^4.3.2"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
         "postcss": "8.5.19",
       },
       "peerDependencies": {
-        "tailwindcss": "4.3.3",
+        "tailwindcss": "^4.3.2",
       },
     },
   },
@@ -960,7 +960,7 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "https://nexus.gsmlg.net/repository/npm/d3-shape/-/d3-shape-1.3.7.tgz", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
-    "duskmoon_storybook/phoenix_duskmoon": ["phoenix_duskmoon@file:apps/phoenix_duskmoon", { "dependencies": { "@duskmoon-dev/art-elements": "1.5.6", "@duskmoon-dev/core": "1.17.0", "@duskmoon-dev/css-art": "1.17.0", "@duskmoon-dev/elements": "1.5.6" }, "devDependencies": { "@mdi/svg": "7.4.47", "bootstrap-icons": "1.13.1", "postcss": "8.5.19" }, "peerDependencies": { "tailwindcss": "4.3.3" } }],
+    "duskmoon_storybook/phoenix_duskmoon": ["phoenix_duskmoon@file:apps/phoenix_duskmoon", { "dependencies": { "@duskmoon-dev/art-elements": "1.5.6", "@duskmoon-dev/core": "1.17.0", "@duskmoon-dev/css-art": "1.17.0", "@duskmoon-dev/elements": "1.5.6" }, "devDependencies": { "@mdi/svg": "7.4.47", "bootstrap-icons": "1.13.1", "postcss": "8.5.19" }, "peerDependencies": { "tailwindcss": "^4.3.2" } }],
 
     "duskmoon_storybook/phoenix_html": ["phoenix_html@file:deps/phoenix_html", {}],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       },
       "name": "phoenix_duskmoon",
       "peerDependencies": {
-        "tailwindcss": "4.3.3"
+        "tailwindcss": "^4.3.2"
       },
       "version": "9.9.0"
     },


### PR DESCRIPTION
## Summary
- widen the published Tailwind peer range to `^4.3.2`
- keep Bun and package-lock workspace metadata aligned
- verify the package against Tailwind CSS 4.3.3 from current `main`

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `mix npm.install --frozen`
- `mix test apps/duskmoon_bundler/test/duskmoon_bundler/tailwind_test.exs` (14 tests, 0 failures)
- `mix duskmoon_bundler.build phoenix_duskmoon`

Fixes #86