### PR TITLE
fix: declare Jason runtime dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,8 +221,7 @@ jobs:
           sed -i "s%{:duskmoon_bundler_runtime, in_umbrella: true}%{:duskmoon_bundler_runtime, \"~> ${VERSION}\"}%" apps/duskmoon_bundler/mix.exs
           sed -i "s%{:duskmoon_npm, in_umbrella: true}%{:duskmoon_npm, \"~> ${VERSION}\"}%" apps/duskmoon_bundler/mix.exs
           sed -i '/^[[:space:]]*{:ex_doc, .*only: :dev, runtime: false},\?$/d' apps/duskmoon_bundler/mix.exs
-          # Transitive production deps pull these without :only restrictions, so avoid packaged mix.exs divergence.
-          sed -i '/^[[:space:]]*{:jason, .*only: :test},\?$/d' apps/phoenix_duskmoon/mix.exs
+          # A transitive production dep pulls ex_doc without an :only restriction, so avoid a dev-only duplicate.
           sed -i '/^[[:space:]]*{:ex_doc, .*only: :dev, runtime: false},\?$/d' apps/phoenix_duskmoon/mix.exs
           grep -q "{:duskmoon_hex_solver, \"~> ${VERSION}\"}" apps/duskmoon_npm/mix.exs
           grep -q "{:duskmoon_oxc, \"~> ${VERSION}\"}" apps/duskmoon_quickbeam/mix.exs
@@ -234,10 +233,6 @@ jobs:
           fi
           if grep -q "{:ex_doc, .*only: :dev" apps/duskmoon_bundler/mix.exs; then
             echo "Bundler packaged mix.exs still contains a dev-only ex_doc dependency" >&2
-            exit 1
-          fi
-          if grep -q "{:jason, .*only: :test" apps/phoenix_duskmoon/mix.exs; then
-            echo "PhoenixDuskmoon packaged mix.exs still contains a test-only jason dependency" >&2
             exit 1
           fi
           if grep -q "{:ex_doc, .*only: :dev" apps/phoenix_duskmoon/mix.exs; then

--- a/apps/phoenix_duskmoon/mix.exs
+++ b/apps/phoenix_duskmoon/mix.exs
@@ -153,7 +153,7 @@ defmodule PhoenixDuskmoon.Mixfile do
       {:mdex_gfm, "~> 0.2.0"},
       {:mdex_mermaid, "~> 0.3.6"},
       {:plug, "~> 1.19", optional: true},
-      {:jason, "~> 1.4", only: :test},
+      {:jason, "~> 1.4"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
## Summary

- declare Jason as a runtime dependency because PhoenixDuskmoon calls `Jason.encode!/1` in production components
- stop deleting Jason from the packaged manifest during releases

## Validation

- `mix test` from `apps/phoenix_duskmoon` — 3,129 tests, 0 failures
- isolated `MIX_ENV=prod mix deps.get`
- isolated `MIX_ENV=prod mix compile --warnings-as-errors`
- `mix format --check-formatted apps/phoenix_duskmoon/mix.exs`
- `git diff --check`

Fixes #87