### PR TITLE
fix: allow dm_input without a value

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
@@ -1089,6 +1089,8 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Input do
 
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   defp dm_input_by_type(assigns) do
+    assigns = assign_new(assigns, :value, fn -> nil end)
+
     ~H"""
     <div class={["form-group", @horizontal && "form-group-horizontal", @errors != [] && "form-group-error", @state && "form-group-#{@state}", @field_class]} phx-feedback-for={@name}>
       <.dm_label for={@id} class={@label_class}>{@label}</.dm_label>

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
@@ -5,6 +5,22 @@ defmodule PhoenixDuskmoon.Component.DataEntry.InputTest do
   import Phoenix.LiveViewTest
   import PhoenixDuskmoon.Component.DataEntry.Input
 
+  describe "generic input type" do
+    test "renders when the optional value is omitted" do
+      result =
+        render_component(&dm_input/1, %{
+          type: "search",
+          name: "q",
+          id: "repository-search",
+          label: "Search code"
+        })
+
+      assert result =~ ~s[type="search"]
+      assert result =~ ~s[name="q"]
+      assert result =~ ~s[id="repository-search"]
+    end
+  end
+
   describe "select input type" do
     test "renders select element with basic attributes" do
       result =


### PR DESCRIPTION
## Summary

- initialize a missing value only in the generic input renderer
- preserve explicit and `Phoenix.HTML.FormField` values
- cover the reported search input without a value

## Validation

- `mix test test/phoenix_duskmoon/component/data_entry/input_test.exs` — 279 tests, 0 failures
- `mix format --check-formatted lib/phoenix_duskmoon/component/data_entry/input.ex test/phoenix_duskmoon/component/data_entry/input_test.exs`
- `git diff --check`

Fixes #88