### PR TITLE
fix: honor resolve_dirs in Tailwind stylesheet imports

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind.ex
@@ -43,6 +43,7 @@ defmodule DuskmoonBundler.Tailwind do
 
     * `:css` — custom input CSS (default: Tailwind's base with theme + preflight + utilities)
     * `:css_base` — base directory for resolving local `@import`, `@reference`, `@plugin`, and `@config` paths
+    * `:resolve_dirs` — additional package directories for resolving bare stylesheet imports
     * `:sources` — override source patterns (default: from config)
     * `:minify` — minify the output CSS (default: `false`)
   """
@@ -64,12 +65,15 @@ defmodule DuskmoonBundler.Tailwind do
   @impl true
   def init(opts) do
     sources = opts[:sources] || DuskmoonBundler.Config.tailwind()[:sources] || []
+    resolve_dirs = normalize_resolve_dirs(opts[:resolve_dirs])
 
     {:ok,
      %{
        runtime: nil,
        scanner: nil,
        sources: sources,
+       default_resolve_dirs: resolve_dirs,
+       resolve_dirs: resolve_dirs,
        last_css: nil
      }}
   end
@@ -119,16 +123,21 @@ defmodule DuskmoonBundler.Tailwind do
     css_base = opts[:css_base] || File.cwd!()
     sources = opts[:sources] || state.sources
 
+    resolve_dirs =
+      opts |> Keyword.get(:resolve_dirs, state.default_resolve_dirs) |> normalize_resolve_dirs()
+
     scanner =
       if(opts[:sources],
         do: build_scanner(sources),
         else: state.scanner || Oxide.new(sources: [])
       )
 
-    case compile_css(state.runtime, css_input, Oxide.scan(scanner), css_base) do
+    case compile_css(state.runtime, css_input, Oxide.scan(scanner), css_base, resolve_dirs) do
       {:ok, css} ->
         css = maybe_minify(css, minify)
-        {:reply, {:ok, css}, %{state | scanner: scanner, last_css: css}}
+
+        {:reply, {:ok, css},
+         %{state | scanner: scanner, resolve_dirs: resolve_dirs, last_css: css}}
 
       {:error, _} = error ->
         {:reply, error, state}
@@ -140,6 +149,9 @@ defmodule DuskmoonBundler.Tailwind do
     minify = Keyword.get(opts, :minify, false)
     css_input = opts[:css]
     css_base = opts[:css_base] || File.cwd!()
+
+    resolve_dirs =
+      opts |> Keyword.get(:resolve_dirs, state.resolve_dirs) |> normalize_resolve_dirs()
 
     changed =
       Enum.map(changed_files, fn
@@ -158,10 +170,16 @@ defmodule DuskmoonBundler.Tailwind do
         if Oxide.scan_files(scanner, changed) == [] do
           {:reply, :unchanged, state}
         else
-          case compile_css(state.runtime, css_input, Oxide.scan(scanner), css_base) do
+          case compile_css(
+                 state.runtime,
+                 css_input,
+                 Oxide.scan(scanner),
+                 css_base,
+                 resolve_dirs
+               ) do
             {:ok, css} ->
               css = maybe_minify(css, minify)
-              {:reply, {:ok, css}, %{state | last_css: css}}
+              {:reply, {:ok, css}, %{state | resolve_dirs: resolve_dirs, last_css: css}}
 
             {:error, _} = error ->
               {:reply, error, state}
@@ -185,11 +203,12 @@ defmodule DuskmoonBundler.Tailwind do
     Oxide.new(sources: oxide_sources)
   end
 
-  defp compile_css(runtime, css_input, candidates, css_base) do
+  defp compile_css(runtime, css_input, candidates, css_base, resolve_dirs) do
     case DuskmoonBundler.JS.Runtime.call(runtime, "compileTailwindCss", [
            css_input,
            candidates,
-           Path.expand(css_base)
+           Path.expand(css_base),
+           resolve_dirs
          ]) do
       {:ok, css} when is_binary(css) -> {:ok, css}
       {:ok, _} -> {:error, :unexpected_result}
@@ -202,6 +221,14 @@ defmodule DuskmoonBundler.Tailwind do
   defp maybe_minify(css, true) do
     {:ok, %{code: minified}} = Vize.CSS.compile(css, minify: true)
     minified
+  end
+
+  defp normalize_resolve_dirs(resolve_dirs) do
+    resolve_dirs
+    |> List.wrap()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&Path.expand/1)
+    |> Enum.uniq()
   end
 
   defp to_oxide_source(%{base: base, pattern: pattern} = source) do

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/loader.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/loader.ex
@@ -15,8 +15,12 @@ defmodule DuskmoonBundler.Tailwind.Loader do
 
   def handlers(runtime_node_modules) do
     %{
-      "tailwind.load_stylesheet" => fn [id, base] ->
-        load_stylesheet(id, base, runtime_node_modules)
+      "tailwind.load_stylesheet" => fn
+        [id, base] ->
+          load_stylesheet(id, base, runtime_node_modules, [])
+
+        [id, base, resolve_dirs] ->
+          load_stylesheet(id, base, runtime_node_modules, resolve_dirs)
       end,
       "tailwind.load_module" => fn [id, base, kind] ->
         load_module(id, base, kind, runtime_node_modules)
@@ -24,8 +28,8 @@ defmodule DuskmoonBundler.Tailwind.Loader do
     }
   end
 
-  defp load_stylesheet(id, base, runtime_node_modules) do
-    path = Resolver.resolve_stylesheet_path!(id, base, runtime_node_modules)
+  defp load_stylesheet(id, base, runtime_node_modules, resolve_dirs) do
+    path = Resolver.resolve_stylesheet_path!(id, base, runtime_node_modules, resolve_dirs)
 
     %{
       base: Path.dirname(path),

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/resolver.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/tailwind/resolver.ex
@@ -8,7 +8,7 @@ defmodule DuskmoonBundler.Tailwind.Resolver do
   @module_conditions ["require", "default", "browser", "import"]
   @stylesheet_conditions ["style", "browser", "import", "default"]
 
-  def resolve_stylesheet_path!(id, base, runtime_node_modules) do
+  def resolve_stylesheet_path!(id, base, runtime_node_modules, resolve_dirs \\ []) do
     base = normalize_base(base)
 
     if NPM.Resolution.PackageResolver.relative?(id) or absolute_specifier?(id) do
@@ -20,7 +20,8 @@ defmodule DuskmoonBundler.Tailwind.Resolver do
         @stylesheet_extensions,
         @stylesheet_index_files,
         "stylesheet",
-        runtime_node_modules
+        runtime_node_modules,
+        resolve_dirs
       )
     end
   end
@@ -37,7 +38,8 @@ defmodule DuskmoonBundler.Tailwind.Resolver do
         @module_extensions,
         @module_index_files,
         kind,
-        runtime_node_modules
+        runtime_node_modules,
+        []
       )
     end
   end
@@ -48,11 +50,19 @@ defmodule DuskmoonBundler.Tailwind.Resolver do
   def relative_specifier?(specifier), do: NPM.Resolution.PackageResolver.relative?(specifier)
   def absolute_specifier?(specifier), do: String.starts_with?(specifier, "/")
 
-  defp resolve_bare_path!(id, base, extensions, index_files, kind, runtime_node_modules) do
+  defp resolve_bare_path!(
+         id,
+         base,
+         extensions,
+         index_files,
+         kind,
+         runtime_node_modules,
+         resolve_dirs
+       ) do
     {package_name, subpath} = NPM.Resolution.PackageResolver.split_specifier(id)
 
     resolved =
-      (node_modules_dirs_for(base) ++ [runtime_node_modules])
+      (node_modules_dirs_for(base) ++ List.wrap(resolve_dirs) ++ [runtime_node_modules])
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
       |> Enum.find_value(fn node_modules ->
@@ -78,7 +88,7 @@ defmodule DuskmoonBundler.Tailwind.Resolver do
         path
 
       nil ->
-        raise "Could not resolve #{kind} #{inspect(id)} from #{inspect(base)}. Add it to node_modules or the Tailwind runtime install."
+        raise "Could not resolve #{kind} #{inspect(id)} from #{inspect(base)}. Add it to node_modules, a configured resolve directory, or the Tailwind runtime install."
     end
   end
 

--- a/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.build.ex
+++ b/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.build.ex
@@ -74,23 +74,31 @@ defmodule Mix.Tasks.DuskmoonBundler.Build do
     outdir = Keyword.get(parsed, :outdir) || to_string(config.outdir)
     minify = Keyword.get(parsed, :minify, config.minify)
 
+    resolve_dirs =
+      case cli_resolve_dirs do
+        [] -> config.resolve_dirs
+        list -> list
+      end
+
     tailwind? =
       Keyword.get(parsed, :tailwind) ||
         (tailwind_config != [] and Keyword.get(parsed, :tailwind, true))
 
     if tailwind? do
-      build_tailwind(parsed, tailwind_config, outdir, minify, config.hash, config.root)
+      build_tailwind(
+        parsed,
+        tailwind_config,
+        outdir,
+        minify,
+        config.hash,
+        config.root,
+        resolve_dirs
+      )
     end
 
     entries =
       case cli_entries do
         [] -> List.wrap(config.entry)
-        list -> list
-      end
-
-    resolve_dirs =
-      case cli_resolve_dirs do
-        [] -> config.resolve_dirs
         list -> list
       end
 
@@ -165,7 +173,15 @@ defmodule Mix.Tasks.DuskmoonBundler.Build do
     end
   end
 
-  defp build_tailwind(parsed, tailwind_config, outdir, minify, config_hash, root) do
+  defp build_tailwind(
+         parsed,
+         tailwind_config,
+         outdir,
+         minify,
+         config_hash,
+         root,
+         resolve_dirs
+       ) do
     cli_sources = Keyword.get_values(parsed, :tailwind_source)
     hash = Keyword.get(parsed, :hash, config_hash)
 
@@ -197,6 +213,7 @@ defmodule Mix.Tasks.DuskmoonBundler.Build do
                  sources: sources,
                  css: css_input,
                  css_base: css_base,
+                 resolve_dirs: resolve_dirs,
                  minify: false
                ) do
           DuskmoonBundler.Builder.Writer.build_style_entry(

--- a/apps/duskmoon_bundler/priv/ts/dev/tailwind.ts
+++ b/apps/duskmoon_bundler/priv/ts/dev/tailwind.ts
@@ -69,10 +69,12 @@ const tailwindExports = requireResolvedModule(tailwindRuntimeSpec, new Map()) as
 async function compileTailwindCss(
   inputCss: string | null,
   candidates: string[] | null,
-  base: string | null
+  base: string | null,
+  resolveDirs: string[] | null = null
 ) {
   const moduleCache = new Map<string, { exports: unknown }>()
   const rootBase = normalizeBase(base, TAILWIND_DEFAULT_BASE)
+  const packageRoots = resolveDirs ?? []
   const css = inputCss == null ? '@import "tailwindcss";' : inputCss
 
   const compiler = await tailwindExports.compile(css, {
@@ -102,7 +104,12 @@ async function compileTailwindCss(
         return { base: rootBase, content: fs.readFileSync(utilitiesCssPath, 'utf8') }
       }
 
-      return Beam.callSync('tailwind.load_stylesheet', id, normalizeBase(currentBase, rootBase))
+      return Beam.callSync(
+        'tailwind.load_stylesheet',
+        id,
+        normalizeBase(currentBase, rootBase),
+        packageRoots
+      )
     },
     loadModule: async (id, currentBase, type) => {
       const spec = Beam.callSync(

--- a/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.build_test.exs
+++ b/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.build_test.exs
@@ -161,4 +161,65 @@ defmodule Mix.Tasks.DuskmoonBundler.BuildTest do
            |> File.ls!()
            |> Enum.any?(&String.match?(&1, ~r/^app-[a-f0-9]{8}\.css$/))
   end
+
+  test "Tailwind build resolves stylesheet imports from configured resolve directories", %{
+    tmp_dir: tmp_dir
+  } do
+    entry = Path.join(tmp_dir, "src/app.js")
+    css_path = Path.join(tmp_dir, "src/app.css")
+    outdir = Path.join(tmp_dir, "dist")
+    deps_dir = Path.join(tmp_dir, "deps")
+    package_dir = Path.join(deps_dir, "phoenix_duskmoon")
+    previous_env = Application.get_all_env(:duskmoon_bundler)
+
+    Application.put_env(:duskmoon_bundler, :issue_89,
+      entry: entry,
+      outdir: outdir,
+      resolve_dirs: [deps_dir],
+      hash: false,
+      minify: false,
+      sourcemap: false,
+      format: :iife,
+      tailwind: [
+        css: css_path,
+        sources: [%{base: Path.join(tmp_dir, "src"), pattern: "**/*"}]
+      ]
+    )
+
+    on_exit(fn ->
+      for {key, _value} <- Application.get_all_env(:duskmoon_bundler) do
+        Application.delete_env(:duskmoon_bundler, key)
+      end
+
+      for {key, value} <- previous_env do
+        Application.put_env(:duskmoon_bundler, key, value)
+      end
+    end)
+
+    File.mkdir_p!(Path.join(package_dir, "priv/static/assets/css"))
+
+    File.write!(
+      Path.join(package_dir, "package.json"),
+      :json.encode(%{
+        "name" => "phoenix_duskmoon",
+        "exports" => %{
+          "./components" => "./priv/static/assets/css/app.css"
+        }
+      })
+    )
+
+    File.write!(
+      Path.join(package_dir, "priv/static/assets/css/app.css"),
+      ".from-resolve-dir { color: rebeccapurple; }"
+    )
+
+    File.write!(entry, "console.log('app')")
+    File.write!(css_path, "@import \"phoenix_duskmoon/components\";\n")
+
+    Mix.Tasks.DuskmoonBundler.Build.run(["issue_89", "--tailwind"])
+
+    css = File.read!(Path.join([outdir, "css", "app.css"]))
+    assert css =~ ".from-resolve-dir"
+    assert css =~ "color: #639"
+  end
 end


### PR DESCRIPTION
## Summary

- pass profile and CLI `resolve_dirs` into Tailwind builds
- resolve bare stylesheet imports from configured package roots before the Tailwind runtime fallback
- keep resolver roots scoped to each build call so named profiles cannot leak paths into one another
- cover a Hex-style package export through the production Mix task

## Validation

- `mix test apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.build_test.exs apps/duskmoon_bundler/test/duskmoon_bundler/tailwind_test.exs` — 19 tests, 0 failures
- `MIX_ENV=test mix compile --warnings-as-errors`
- scoped `mix format --check-formatted`
- `git diff --check`

Fixes #89