### PR TITLE
fix: render dm_btn links as single controls

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -249,23 +249,28 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   end
 
   def dm_btn(%{} = assigns) do
-    assigns = assign_button_element(assigns)
+    link? =
+      is_binary(assigns.navigate) || is_binary(assigns.patch) ||
+        (!is_nil(assigns.href) && assigns.href != "#")
+
+    assigns =
+      assigns
+      |> then(fn assigns ->
+        if link?, do: assign_button_style(assigns), else: assign_button_element(assigns)
+      end)
+      |> assign(:link?, link?)
 
     ~H"""
-    <.button_link :if={is_binary(@navigate)} navigate={@navigate} replace={@replace}>
-      <.button_element {assigns} />
-    </.button_link>
-    <.button_link :if={!is_binary(@navigate) && is_binary(@patch)} patch={@patch} replace={@replace}>
-      <.button_element {assigns} />
-    </.button_link>
-    <.button_link
-      :if={!is_binary(@navigate) && !is_binary(@patch) && !is_nil(@href) && @href != "#"}
-      href={@href}
-    >
-      <.button_element {assigns} />
-    </.button_link>
-    <.button_element :if={!is_binary(@navigate) && !is_binary(@patch) && (is_nil(@href) || @href == "#")} {assigns} />
+    <.button_link :if={@link?} {assigns} />
+    <.button_element :if={!@link?} {assigns} />
     """
+  end
+
+  defp assign_button_style(assigns) do
+    assigns
+    |> assign_new(:id, fn -> nil end)
+    |> assign(:el_variant, map_variant(assigns.variant))
+    |> assign(:el_style, variant_style(assigns.variant))
   end
 
   defp assign_button_element(assigns) do
@@ -273,10 +278,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
     assigns
     |> assign(:rest, rest_without_onclick(assigns.rest, submit_onclick))
-    |> assign_new(:id, fn -> nil end)
-    |> assign(:el_variant, map_variant(assigns.variant))
-    |> assign(:el_style, variant_style(assigns.variant))
     |> assign(:submit_onclick, submit_onclick)
+    |> assign_button_style()
   end
 
   attr(:id, :any, default: nil)
@@ -321,24 +324,73 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   attr(:patch, :string, default: nil)
   attr(:href, :any, default: nil)
   attr(:replace, :boolean, default: false)
-  slot(:inner_block, required: true)
+  attr(:id, :any, default: nil)
+  attr(:el_variant, :string, default: nil)
+  attr(:size, :string, default: nil)
+  attr(:shape, :string, default: nil)
+  attr(:loading, :boolean, default: false)
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :any, default: nil)
+  attr(:el_style, :string, default: nil)
+  attr(:rest, :global)
+  slot(:inner_block)
+  slot(:prefix)
+  slot(:suffix)
 
-  defp button_link(%{navigate: to} = assigns) when is_binary(to) do
+  defp button_link(assigns) do
+    assigns =
+      assigns
+      |> assign(:button_class, [
+        "btn",
+        "btn-#{assigns.el_variant || "primary"}",
+        assigns.size && "btn-#{assigns.size}",
+        assigns.shape && "btn-#{assigns.shape}",
+        assigns.loading && "btn-loading",
+        assigns.disabled && "opacity-50",
+        assigns.disabled && "cursor-not-allowed",
+        assigns.disabled && "pointer-events-none",
+        assigns.class
+      ])
+      |> assign(:inert_rest, inert_link_rest(assigns.rest))
+
     ~H"""
-    <.link navigate={@navigate} replace={@replace}>{render_slot(@inner_block)}</.link>
+    <.link
+      :if={!@disabled && !@loading}
+      navigate={@navigate}
+      patch={@patch}
+      href={@href}
+      replace={@replace}
+      id={@id}
+      class={@button_class}
+      style={@el_style}
+      {@rest}
+    >
+      <span :for={prefix <- @prefix} class="inline-flex items-center">{render_slot(prefix)}</span>
+      {render_slot(@inner_block)}
+      <span :for={suffix <- @suffix} class="inline-flex items-center">{render_slot(suffix)}</span>
+    </.link>
+    <a
+      :if={@disabled || @loading}
+      id={@id}
+      role="link"
+      class={@button_class}
+      style={@el_style}
+      aria-disabled="true"
+      aria-busy={@loading && "true"}
+      {@inert_rest}
+    >
+      <span :for={prefix <- @prefix} class="inline-flex items-center">{render_slot(prefix)}</span>
+      {render_slot(@inner_block)}
+      <span :for={suffix <- @suffix} class="inline-flex items-center">{render_slot(suffix)}</span>
+    </a>
     """
   end
 
-  defp button_link(%{patch: to} = assigns) when is_binary(to) do
-    ~H"""
-    <.link patch={@patch} replace={@replace}>{render_slot(@inner_block)}</.link>
-    """
-  end
-
-  defp button_link(%{href: href} = assigns) when not is_nil(href) and href != "#" do
-    ~H"""
-    <.link href={@href}>{render_slot(@inner_block)}</.link>
-    """
+  defp inert_link_rest(rest) do
+    Map.reject(rest, fn {key, _value} ->
+      key = to_string(key)
+      key == "tabindex" || String.starts_with?(key, ["on", "phx-"])
+    end)
   end
 
   # WORKAROUND(upstream): duskmoon-dev/duskmoon-elements#66

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -115,20 +115,21 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     refute result =~ "aria-disabled"
   end
 
-  test "renders navigate button as link with button styling" do
+  test "renders navigate button as one link with button styling" do
     result =
       render_component(&dm_btn/1, %{
         navigate: "/dashboard",
-        variant: "ghost",
         inner_block: %{inner_block: fn _, _ -> "Dashboard" end}
       })
 
+    assert [_] = Regex.scan(~r/<a\b/, result)
     assert result =~ ~s[<a]
     assert result =~ ~s[href="/dashboard"]
     assert result =~ ~s[data-phx-link="redirect"]
     assert result =~ ~s[data-phx-link-state="push"]
-    assert result =~ ~s[<el-dm-button]
-    assert result =~ ~s[variant="ghost"]
+    assert result =~ ~s[class="btn btn-primary"]
+    refute result =~ ~s[<el-dm-button]
+    refute result =~ ~s[<button]
     assert result =~ "Dashboard"
   end
 
@@ -141,29 +142,82 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
         inner_block: %{inner_block: fn _, _ -> "Profile" end}
       })
 
+    assert [_] = Regex.scan(~r/<a\b/, result)
     assert result =~ ~s[href="/settings?tab=profile"]
     assert result =~ ~s[data-phx-link="patch"]
     assert result =~ ~s[data-phx-link-state="replace"]
-    assert result =~ ~s[variant="outline"]
+    assert result =~ ~s[class="btn btn-outline"]
+    refute result =~ ~s[<el-dm-button]
+    refute result =~ ~s[<button]
   end
 
   test "renders href button as link with styling attributes" do
     result =
       render_component(&dm_btn/1, %{
+        id: "external-action",
         href: "https://example.com",
         variant: "error",
         size: "lg",
         class: "external-action",
+        rest: %{"aria-label" => "External site", "rel" => "noopener", "target" => "_blank"},
         inner_block: %{inner_block: fn _, _ -> "External" end}
       })
 
+    assert [_] = Regex.scan(~r/<a\b/, result)
     assert result =~ ~s[<a]
+    assert result =~ ~s[id="external-action"]
     assert result =~ ~s[href="https://example.com"]
-    assert result =~ ~s[variant="primary"]
+    assert result =~ ~s[class="btn btn-primary btn-lg external-action"]
+    assert result =~ ~s[aria-label="External site"]
+    assert result =~ ~s[rel="noopener"]
+    assert result =~ ~s[target="_blank"]
     assert result =~ "--color-primary: var(--color-error)"
-    assert result =~ ~s[size="lg"]
-    assert result =~ "external-action"
+    refute result =~ ~s[<el-dm-button]
+    refute result =~ ~s[<button]
     assert result =~ "External"
+  end
+
+  test "renders disabled link button as an inert control" do
+    result =
+      render_component(&dm_btn/1, %{
+        navigate: "/dashboard",
+        disabled: true,
+        rest: %{
+          "aria-label" => "Dashboard unavailable",
+          "onclick" => "alert('clicked')",
+          "phx-click" => "navigate",
+          "tabindex" => "0"
+        },
+        inner_block: %{inner_block: fn _, _ -> "Dashboard" end}
+      })
+
+    assert [_] = Regex.scan(~r/<a\b/, result)
+    assert result =~ ~s[role="link"]
+    assert result =~ ~s[aria-disabled="true"]
+    assert result =~ ~s[aria-label="Dashboard unavailable"]
+    assert result =~ "opacity-50"
+    assert result =~ "cursor-not-allowed"
+    assert result =~ "pointer-events-none"
+    refute result =~ ~s[href=]
+    refute result =~ ~s[data-phx-link=]
+    refute result =~ ~s[onclick=]
+    refute result =~ ~s[phx-click=]
+    refute result =~ ~s[tabindex=]
+  end
+
+  test "renders loading link button without an active destination" do
+    result =
+      render_component(&dm_btn/1, %{
+        href: "https://example.com",
+        loading: true,
+        inner_block: %{inner_block: fn _, _ -> "Loading" end}
+      })
+
+    assert [_] = Regex.scan(~r/<a\b/, result)
+    assert result =~ "btn-loading"
+    assert result =~ ~s[aria-disabled="true"]
+    assert result =~ ~s[aria-busy="true"]
+    refute result =~ ~s[href=]
   end
 
   test "renders button with noise effect" do


### PR DESCRIPTION
## Summary

- render navigate, patch, and href button variants as a single native link styled with DuskMoon button classes
- forward semantic link attributes directly to the focusable control
- make disabled and loading link states inert while preserving accessible state and styling

## Tests

- `mix test test/phoenix_duskmoon/component/action/button_test.exs` (57 tests, 0 failures)
- `mix compile --force --warnings-as-errors`

Fixes #90