### PR TITLE
fix: remove invalid table row-group roles

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/table.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/table.ex
@@ -163,7 +163,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Table do
         id={caption[:id]}
         class={caption[:class]}
       >{render_slot(caption)}</caption>
-      <thead role="row-group" class="hidden md:table-header-group sticky top-0">
+      <thead class="hidden md:table-header-group sticky top-0">
         <tr role="row">
           <th
             :for={col <- @col}
@@ -173,7 +173,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Table do
           >{col.label}</th>
         </tr>
       </thead>
-      <tbody :if={@stream} role="row-group" id={@id && "#{@id}-stream-body"} phx-update="stream">
+      <tbody :if={@stream} id={@id && "#{@id}-stream-body"} phx-update="stream">
         <tr
           :for={{row_id, row} <- @data}
           role="row"
@@ -187,7 +187,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Table do
           >{render_slot(col, row)}</td>
         </tr>
       </tbody>
-      <tbody :if={!@stream} role="row-group">
+      <tbody :if={!@stream}>
         <%= for row <- @data do %>
           <tr
             role="row"

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/table_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/table_test.exs
@@ -71,7 +71,9 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.TableTest do
         })
 
       assert result =~ ~s[role="table"]
-      assert result =~ ~s[role="row-group"]
+      assert result =~ "<thead"
+      assert result =~ "<tbody"
+      refute result =~ ~r/<(?:thead|tbody)\b[^>]*\srole=/
       assert result =~ ~s[role="row"]
       assert result =~ ~s[role="cell"]
       assert result =~ "Alice"
@@ -275,6 +277,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.TableTest do
       assert result =~ ~s[id="row-2"]
       assert result =~ "Alice"
       assert result =~ "Bob"
+      refute result =~ ~r/<tbody\b[^>]*\srole=/
     end
 
     test "renders table without caption by default" do


### PR DESCRIPTION
## Summary

- remove invalid `role="row-group"` attributes from native table header and body groups
- rely on the implicit `rowgroup` semantics of `thead` and `tbody`
- cover both normal and streamed table bodies with regressions

## Tests

- `mix test test/phoenix_duskmoon/component/data_display/table_test.exs` (43 tests, 0 failures)
- `mix compile --force --warnings-as-errors`

Fixes #91