### PR TITLE
fix: restore focus to popover trigger controls

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/popover.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/popover.ex
@@ -25,6 +25,12 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Popover do
   """
   use Phoenix.Component
 
+  # WORKAROUND(upstream): duskmoon-dev/duskmoon-elements#69
+  @restore_trigger_focus """
+  const trigger = this.querySelector("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])") || this.firstElementChild;
+  trigger?.focus();
+  """
+
   @doc """
   Renders a popover with trigger and floating content.
 
@@ -74,6 +80,14 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Popover do
   slot(:inner_block, doc: "Popover content")
 
   def dm_popover(assigns) do
+    restore_trigger_focus =
+      if assigns.trigger_mode == "focus", do: nil, else: @restore_trigger_focus
+
+    assigns =
+      assigns
+      |> assign(:restore_trigger_focus, restore_trigger_focus)
+      |> assign(:trigger_tabindex, restore_trigger_focus && "-1")
+
     ~H"""
     <el-dm-popover
       id={@id}
@@ -85,7 +99,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Popover do
       class={@class}
       {@rest}
     >
-      <div slot="trigger">
+      <div slot="trigger" tabindex={@trigger_tabindex} onfocus={@restore_trigger_focus}>
         {render_slot(@trigger)}
       </div>
       {render_slot(@inner_block)}

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/popover_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/popover_test.exs
@@ -8,6 +8,17 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.PopoverTest do
     [%{__slot__: :trigger, inner_block: fn _, _ -> "Trigger" end}]
   end
 
+  defp button_trigger_slot do
+    [
+      %{
+        __slot__: :trigger,
+        inner_block: fn _, _ ->
+          Phoenix.HTML.raw(~s(<button type="button">Code</button>))
+        end
+      }
+    ]
+  end
+
   describe "dm_popover basic rendering" do
     test "renders el-dm-popover element" do
       result = render_component(&dm_popover/1, %{trigger: trigger_slot()})
@@ -140,9 +151,26 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.PopoverTest do
   end
 
   describe "dm_popover trigger structure" do
-    test "trigger is wrapped in div with slot=trigger" do
-      result = render_component(&dm_popover/1, %{trigger: trigger_slot()})
-      assert result =~ ~s(<div slot="trigger">)
+    test "trigger wrapper delegates restored focus to the authored control" do
+      result = render_component(&dm_popover/1, %{trigger: button_trigger_slot()})
+
+      assert result =~ ~s(<div slot="trigger")
+      assert result =~ ~s(tabindex="-1")
+      assert result =~ ~s(onfocus=")
+      assert result =~ "querySelector"
+      assert result =~ ".focus()"
+      assert result =~ ~s(<button type="button">Code</button>)
+    end
+
+    test "focus-triggered wrapper stays non-focusable so Escape does not reopen it" do
+      result =
+        render_component(&dm_popover/1, %{
+          trigger_mode: "focus",
+          trigger: button_trigger_slot()
+        })
+
+      refute result =~ ~s(tabindex="-1")
+      refute result =~ ~s(onfocus=")
     end
   end
 


### PR DESCRIPTION
## Summary

- make click and hover popover trigger wrappers programmatically focusable without adding a Tab stop
- delegate restored wrapper focus to the authored focusable control
- keep focus-triggered wrappers non-focusable so Escape does not immediately reopen the popover
- track the complete dependency-level fix in duskmoon-dev/duskmoon-elements#69

## Tests

- `mix test test/phoenix_duskmoon/component/data_display/popover_test.exs` (31 tests, 0 failures)
- `mix compile --force --warnings-as-errors`
- browser smoke with `@duskmoon-dev/el-popover`: Escape closed the popover and restored `document.activeElement` to the authored trigger button

Fixes #92