### PR TITLE
fix: omit empty input labels

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
@@ -1091,7 +1091,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Input do
   defp dm_input_by_type(assigns) do
     ~H"""
     <div class={["form-group", @horizontal && "form-group-horizontal", @errors != [] && "form-group-error", @state && "form-group-#{@state}", @field_class]} phx-feedback-for={@name}>
-      <.dm_label for={@id} class={@label_class}>{@label}</.dm_label>
+      <.dm_label :if={@label} for={@id} class={@label_class}>{@label}</.dm_label>
       <div class="flex flex-col gap-2">
         <input
           type={@type}

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
@@ -689,6 +689,20 @@ defmodule PhoenixDuskmoon.Component.DataEntry.InputTest do
       assert result =~ "Username"
     end
 
+    test "omits label when label is not provided" do
+      result =
+        render_component(&dm_input/1, %{
+          type: "text",
+          name: "filter[key]",
+          value: nil,
+          "aria-label": "Label key"
+        })
+
+      assert result =~ ~s(name="filter[key]")
+      assert result =~ ~s[aria-label="Label key"]
+      refute result =~ "<label"
+    end
+
     test "renders text input with value" do
       result =
         render_component(&dm_input/1, %{


### PR DESCRIPTION
## Summary
- omit the standalone label for ordinary inputs when `label` is `nil`
- preserve caller-provided accessible names and other global input attributes
- cover the reported unlabeled inline-filter input with a regression test

## Validation
- `mix test apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs` — 279 tests, 0 failures
- scoped `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `git diff --check`

Fixes #100