### PR TITLE
fix: update npm Req pool timeout option

### DIFF
--- a/apps/duskmoon_npm/lib/npm/tarball.ex
+++ b/apps/duskmoon_npm/lib/npm/tarball.ex
@@ -43,7 +43,7 @@ defmodule NPM.Tarball do
     case Req.get(tarball_url,
            decode_body: false,
            connect_options: [timeout: @connect_timeout],
-           pool_timeout: @pool_timeout,
+           finch: [pool_timeout: @pool_timeout],
            receive_timeout: @receive_timeout,
            retry: false
          ) do


### PR DESCRIPTION
## Summary
- configure the tarball fetch pool timeout through Req’s Finch options
- preserve the existing connection, receive, and retry behavior
- verify the duskmoon_npm cache tests and warning-free umbrella compilation

Fixes #108