### PR TITLE
fix: start bundler runtime in tests

### DIFF
--- a/apps/duskmoon_bundler/CHANGELOG.md
+++ b/apps/duskmoon_bundler/CHANGELOG.md
@@ -8,11 +8,12 @@
 
 ### Changed
 - Production manifests now include `manifest_version: 1` and an `entries` object while the runtime reader remains compatible with legacy flat manifests.
-- Phoenix projects should depend on both `:duskmoon_bundler_runtime` and `:duskmoon_bundler`, with `:duskmoon_bundler` configured as `runtime: Mix.env() == :dev`.
+- Phoenix projects should depend on both `:duskmoon_bundler_runtime` and `:duskmoon_bundler`, with `:duskmoon_bundler` configured as `runtime: Mix.env() in [:dev, :test]`.
 - HMR websocket messages (`ping`, `pong`, `update`, `error`) now flow through `DuskmoonBundler.HMR.Message`, which uses `JSONCodec` for struct<->JSON (de)serialization with `Jason` performing the final binary encoding.
 - Added `json_codec` as a runtime dependency.
 
 ### Fixed
+- Generated installs now start `:duskmoon_bundler` in test, ensuring endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 - HMR websocket no longer drops idle connections after 60 seconds. The browser client now sends a periodic `{"type":"ping"}` heartbeat, and the server replies with `{"type":"pong"}`, preventing Bandit's websocket `read_timeout` from closing an otherwise idle socket. The client also tracks pongs and force-reconnects if the link goes half-open. This eliminates the spurious `[DuskmoonBundler] Disconnected. Reconnecting...` console noise observed on long-lived demo/dev pages with no file changes.
 
 ## 0.14.6

--- a/apps/duskmoon_bundler/README.md
+++ b/apps/duskmoon_bundler/README.md
@@ -35,7 +35,7 @@ Or add the dep manually:
 def deps do
   [
     {:duskmoon_bundler_runtime, "~> 9.7"},
-    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
   ]
 end
 ```

--- a/apps/duskmoon_bundler/guides/deployment/production-builds.md
+++ b/apps/duskmoon_bundler/guides/deployment/production-builds.md
@@ -28,7 +28,7 @@ Production builds run the same framework/plugin compilation pipeline as the dev 
 - writes a manifest that Phoenix can use for digested asset paths and chunk preload metadata
 - optionally copies a Vite-style public directory to the static root without transforming files
 
-Phoenix releases that call `DuskmoonBundler.static_path/2` or `DuskmoonBundler.Preload.tags/2` only need `:duskmoon_bundler_runtime` at runtime. Keep `:duskmoon_bundler` available for build aliases with `runtime: Mix.env() == :dev`; do not mark it `only: :dev`, because asset deploy aliases often run under `MIX_ENV=prod`.
+Phoenix releases that call `DuskmoonBundler.static_path/2` or `DuskmoonBundler.Preload.tags/2` only need `:duskmoon_bundler_runtime` at runtime. Keep `:duskmoon_bundler` available for build aliases with `runtime: Mix.env() in [:dev, :test]`; do not mark it `only: :dev`, because asset deploy aliases often run under `MIX_ENV=prod`. Starting the app in test ensures endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 
 ## Public files in Phoenix apps
 

--- a/apps/duskmoon_bundler/guides/introduction/getting-started.md
+++ b/apps/duskmoon_bundler/guides/introduction/getting-started.md
@@ -7,7 +7,7 @@ mix igniter.install duskmoon_bundler
 ```
 
 The installer:
-- Adds `{:duskmoon_bundler_runtime, "~> 9.7"}` and `{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}` to `mix.exs`
+- Adds `{:duskmoon_bundler_runtime, "~> 9.7"}` and `{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}` to `mix.exs`
 - Configures build settings in `config/config.exs`
 - Adds format and lint config to `config/config.exs`
 - Adds `DuskmoonBundler.Formatter` plugin to `.formatter.exs`
@@ -30,12 +30,12 @@ Add DuskmoonBundler to your dependencies:
 def deps do
   [
     {:duskmoon_bundler_runtime, "~> 9.7"},
-    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
   ]
 end
 ```
 
-Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option keeps build/dev tooling out of production releases while still making Mix tasks available.
+Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option starts the DevServer and its cache/HMR supervision tree in development and code-reloading tests, keeps build/dev tooling out of production releases, and still makes Mix tasks available.
 
 ### Build Configuration
 

--- a/apps/duskmoon_bundler/guides/migration/from-esbuild.md
+++ b/apps/duskmoon_bundler/guides/migration/from-esbuild.md
@@ -23,10 +23,10 @@ Add:
 
 ```elixir
 {:duskmoon_bundler_runtime, "~> 9.7"},
-{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
 ```
 
-Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option keeps the build/dev app out of production releases.
+Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option starts the DevServer and its cache/HMR supervision tree in development and code-reloading tests while keeping the build/dev app out of production releases.
 
 ### 2. Replace Config
 

--- a/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.install.ex
+++ b/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.install.ex
@@ -73,7 +73,7 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp add_duskmoon_deps(igniter) do
-      runtime_setting = Sourceror.parse_string!("Mix.env() == :dev")
+      runtime_setting = Sourceror.parse_string!("Mix.env() in [:dev, :test]")
 
       igniter
       |> ProjectDeps.add_dep({:duskmoon_bundler_runtime, "~> 9.7"}, on_exists: :skip)

--- a/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.install_test.exs
+++ b/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.install_test.exs
@@ -123,7 +123,10 @@ defmodule DuskmoonBundler.InstallTest do
         |> Rewrite.Source.get(:content)
 
       assert mix_content =~ ~s({:duskmoon_bundler_runtime, "~> 9.7"})
-      assert mix_content =~ "{:duskmoon_bundler, \"~> 9.7\", runtime: Mix.env() == :dev}"
+
+      assert mix_content =~
+               "{:duskmoon_bundler, \"~> 9.7\", runtime: Mix.env() in [:dev, :test]}"
+
       assert mix_content =~ ~s("assets.setup": [])
       assert mix_content =~ ~s("assets.build": ["compile", "duskmoon_bundler.build --tailwind"])
 


### PR DESCRIPTION
## Summary
- configure generated installs to start DuskmoonBundler in development and test
- cover the generated dependency declaration with the installer test
- update the README, guides, and changelog to document code-reloading test support

Fixes #107