### PR TITLE
fix: start SSL for npm CI installs

### DIFF
--- a/apps/duskmoon_npm/lib/mix/tasks/npm.ci.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.ci.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Npm.Ci do
 
   @impl true
   def run([]) do
+    Application.ensure_all_started(:ssl)
     Application.ensure_all_started(:req)
 
     case NPM.install(frozen: true) do

--- a/apps/duskmoon_npm/mix.exs
+++ b/apps/duskmoon_npm/mix.exs
@@ -28,7 +28,7 @@ defmodule DuskmoonNpm.MixProject do
   end
 
   def application do
-    [extra_applications: [:crypto]]
+    [extra_applications: [:crypto, :ssl]]
   end
 
   defp aliases do

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -269,6 +269,29 @@ defmodule NPM.InstallTest do
     assert output =~ "package-lock.json not found. Run `mix npm.install` first."
   end
 
+  test "npm.ci starts SSL before installing", %{project_dir: project_dir} do
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{"name" => "ssl_startup_project"})
+    )
+
+    {:ok, _started} = Application.ensure_all_started(:ssl)
+    on_exit(fn -> Application.ensure_all_started(:ssl) end)
+    assert :ok = Application.stop(:ssl)
+    refute List.keymember?(Application.started_applications(), :ssl, 0)
+
+    Mix.Task.reenable("npm.ci")
+
+    capture_io(fn ->
+      assert :ok = Mix.Tasks.Npm.Ci.run([])
+    end)
+
+    assert {:ssl, _description, _version} =
+             List.keyfind(Application.started_applications(), :ssl, 0)
+
+    assert :ssl in Application.spec(:duskmoon_npm, :applications)
+  end
+
   defp write_cached_package!(name, version) do
     cache_path = NPM.Cache.package_dir(name, version)
     File.mkdir_p!(cache_path)


### PR DESCRIPTION
## Summary
- declare SSL as a duskmoon_npm runtime application
- ensure mix npm.ci starts SSL before Req performs HTTPS fetches
- add a regression test that stops SSL and verifies npm.ci restarts it

Fixes #106