### PR TITLE
fix: run bundle traversal on a guarded stack

### DIFF
--- a/apps/duskmoon_oxc/native/oxc_ex_nif/src/bundle.rs
+++ b/apps/duskmoon_oxc/native/oxc_ex_nif/src/bundle.rs
@@ -24,6 +24,12 @@ use crate::atoms;
 use crate::error::error_to_term;
 use crate::options::{BundleEntry, BundleOptions};
 
+// Rolldown and OXC recursively traverse generated expression trees. Run the
+// complete bundle operation away from the comparatively small dirty NIF stack.
+// The standard library reserves this address space without committing it
+// upfront on supported platforms, including Windows.
+const BUNDLE_STACK_SIZE: usize = 64 * 1024 * 1024;
+
 #[derive(Serialize)]
 struct CodeWithSourcemap {
     code: String,
@@ -48,6 +54,22 @@ struct BundleRunOutput {
     imports: Vec<String>,
     dynamic_imports: Vec<String>,
     exports: Vec<String>,
+}
+
+fn run_bundle_operation<T: Send>(
+    operation: impl FnOnce() -> Result<T, Vec<String>> + Send,
+) -> Result<T, Vec<String>> {
+    std::thread::scope(|scope| {
+        let worker = std::thread::Builder::new()
+            .name("oxc-bundle".to_string())
+            .stack_size(BUNDLE_STACK_SIZE)
+            .spawn_scoped(scope, operation)
+            .map_err(|error| vec![format!("Failed to start bundle worker: {error}")])?;
+
+        worker
+            .join()
+            .map_err(|_| vec!["Bundle worker panicked".to_string()])?
+    })
 }
 
 fn normalize_virtual_path(path: &str) -> Result<PathBuf, String> {
@@ -644,7 +666,7 @@ fn output_path(opts: &BundleOptions<'_>, filename: &str) -> Option<String> {
 pub fn bundle_run<'a>(env: Env<'a>, opts_term: Term<'a>) -> NifResult<Term<'a>> {
     let opts = BundleOptions::from_term(opts_term);
 
-    match bundle_run_project(&opts) {
+    match run_bundle_operation(|| bundle_run_project(&opts)) {
         Ok(result) => Ok((atoms::ok(), result).encode(env)),
         Err(errors) => error_to_term(env, &errors),
     }
@@ -658,7 +680,7 @@ pub fn bundle<'a>(
 ) -> NifResult<Term<'a>> {
     let opts = BundleOptions::from_term(opts_term);
 
-    match bundle_virtual_project(files, &opts) {
+    match run_bundle_operation(|| bundle_virtual_project(files, &opts)) {
         Ok((code, Some(sourcemap))) => Ok((
             atoms::ok(),
             SerdeTerm(CodeWithSourcemap { code, sourcemap }),
@@ -673,7 +695,7 @@ pub fn bundle<'a>(
 pub fn bundle_entry<'a>(env: Env<'a>, entry: String, opts_term: Term<'a>) -> NifResult<Term<'a>> {
     let opts = BundleOptions::from_term(opts_term);
 
-    match bundle_filesystem_entry(entry, &opts) {
+    match run_bundle_operation(|| bundle_filesystem_entry(entry, &opts)) {
         Ok((code, Some(sourcemap))) => Ok((
             atoms::ok(),
             SerdeTerm(CodeWithSourcemap { code, sourcemap }),

--- a/apps/duskmoon_oxc/test/oxc/bundle_test.exs
+++ b/apps/duskmoon_oxc/test/oxc/bundle_test.exs
@@ -1,0 +1,59 @@
+defmodule OXC.BundleTest do
+  use ExUnit.Case, async: true
+
+  @app_dir Path.expand("../..", __DIR__)
+
+  @tag :tmp_dir
+  test "bundles a deeply nested expression without crashing the native runtime", %{
+    tmp_dir: tmp_dir
+  } do
+    mix = System.find_executable("mix") || flunk("mix executable not found")
+
+    expression =
+      Enum.reduce(1..500, "0", fn _, expression ->
+        "identity(#{expression})"
+      end)
+
+    source = """
+    const identity = value => value;
+    export const result = #{expression};
+    """
+
+    child_script = """
+    source = System.fetch_env!("OXC_DEEP_EXPRESSION_SOURCE")
+
+    case OXC.bundle([{"deep-expression.js", source}],
+           entry: "deep-expression.js",
+           format: :esm,
+           treeshake: true
+         ) do
+      {:ok, bundle} when is_binary(bundle) ->
+        if bundle =~ "identity" and bundle =~ "result" do
+          IO.puts("bundle-ok")
+        else
+          System.halt(2)
+        end
+
+      result ->
+        IO.inspect(result, label: "bundle-error")
+        System.halt(3)
+    end
+    """
+
+    assert {output, 0} =
+             System.cmd(
+               mix,
+               ["run", "--no-compile", "-e", child_script],
+               cd: @app_dir,
+               env: [
+                 {"MIX_ENV", "test"},
+                 {"OXC_DEEP_EXPRESSION_SOURCE", source},
+                 {"ERL_CRASH_DUMP", Path.join(tmp_dir, "erl_crash.dump")},
+                 {"ERL_CRASH_DUMP_SECONDS", "0"}
+               ],
+               stderr_to_stdout: true
+             )
+
+    assert output =~ "bundle-ok"
+  end
+end

--- a/apps/duskmoon_oxc/test/test_helper.exs
+++ b/apps/duskmoon_oxc/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- run OXC and Rolldown bundle operations on a scoped worker with a 64 MiB stack
- convert worker creation and panic failures into normal bundler diagnostics
- add a child-BEAM regression that bundles a deeply nested expression without crashing

Fixes #104