### PR TITLE
fix: preserve optional nested dependency graphs

### DIFF
--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -500,25 +500,29 @@ defmodule NPM do
     Enum.reduce(lockfile, lockfile, fn {_name, entry}, acc ->
       entry
       |> Map.get(:optional_dependencies, %{})
-      |> Enum.reduce(acc, &maybe_add_optional_dep/2)
+      |> Enum.reduce(acc, &expand_dependency/2)
     end)
   end
 
-  defp maybe_add_optional_dep({name, _range}, acc) when is_map_key(acc, name), do: acc
+  defp expand_dependency({name, _range}, acc) when is_map_key(acc, name), do: acc
 
-  defp maybe_add_optional_dep({name, range}, acc) do
+  defp expand_dependency({name, range}, acc) do
     case resolve_version(name, range) do
       {:ok, version_str, info} ->
         warn_age_heuristics(name, version_str, info)
 
-        Map.put(acc, name, %{
+        entry = %{
           version: version_str,
           integrity: info.dist.integrity,
           tarball: info.dist.tarball,
           dependencies: info.dependencies,
           optional_dependencies: Map.get(info, :optional_dependencies, %{}),
           has_install_script: Map.get(info, :has_install_script, false)
-        })
+        }
+
+        entry.dependencies
+        |> Map.merge(entry.optional_dependencies)
+        |> Enum.reduce(Map.put(acc, name, entry), &expand_dependency/2)
 
       :error ->
         acc

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -361,7 +361,25 @@ defmodule NPM do
         Path.join([@node_modules, name, "package.json"]) |> File.exists?()
       end)
 
-    lockfile_intact? and local_links_intact?
+    nested_lockfile_intact? =
+      case NPM.Lockfile.read_nested() do
+        {:ok, nested_lockfile} ->
+          Enum.all?(nested_lockfile, fn {location, _entry} ->
+            nested_location_skipped?(location, skipped) or
+              Path.join(location, "package.json") |> File.exists?()
+          end)
+
+        {:error, _reason} ->
+          false
+      end
+
+    lockfile_intact? and nested_lockfile_intact? and local_links_intact?
+  end
+
+  defp nested_location_skipped?(location, skipped) do
+    Enum.any?(skipped, fn name ->
+      String.starts_with?(location, "node_modules/#{name}/node_modules/")
+    end)
   end
 
   defp resolve_and_install(deps, old_lockfile, local_links) do
@@ -383,12 +401,12 @@ defmodule NPM do
           Mix.shell().info("  (#{map_size(nested_info)} packages with nested versions)")
         end
 
-        lockfile = build_lockfile(flat)
-        lockfile = expand_all_optional_deps(lockfile)
         nested_lockfile = build_nested_lockfile(nested_info, flat)
+        lockfile = build_lockfile(flat)
+        {lockfile, nested_lockfile} = expand_all_optional_deps(lockfile, nested_lockfile)
         print_lockfile_diff(old_lockfile, lockfile)
         NPM.Lockfile.write(lockfile, nested: nested_lockfile)
-        link_and_nest(lockfile, nested_info, flat, local_links)
+        link_from_lockfile(lockfile, local_links, nested_lockfile)
 
       {:error, message} ->
         Mix.shell().error("Resolution failed:\n#{message}")
@@ -396,14 +414,15 @@ defmodule NPM do
     end
   end
 
-  defp link_and_nest(lockfile, nested_info, flat, local_links) do
-    with :ok <- link_from_lockfile(lockfile, local_links) do
-      if nested_info != %{}, do: Linker.link_nested(nested_info, flat, @node_modules)
-      :ok
+  defp link_from_lockfile(lockfile, local_links, nested_lockfile \\ :read)
+
+  defp link_from_lockfile(lockfile, local_links, :read) do
+    with {:ok, nested_lockfile} <- NPM.Lockfile.read_nested() do
+      link_from_lockfile(lockfile, local_links, nested_lockfile)
     end
   end
 
-  defp link_from_lockfile(lockfile, local_links) do
+  defp link_from_lockfile(lockfile, local_links, nested_lockfile) do
     skipped = Linker.skipped_packages(lockfile)
     linkable_lockfile = linkable_lockfile(lockfile, skipped)
     total = length(linkable_lockfile)
@@ -419,7 +438,14 @@ defmodule NPM do
 
     {link_us, result} =
       :timer.tc(fn ->
-        with :ok <- Linker.link(lockfile, @node_modules, :symlink, skipped) do
+        with :ok <- Linker.link(lockfile, @node_modules, :symlink, skipped),
+             :ok <-
+               Linker.link_nested_lockfile(
+                 nested_lockfile,
+                 @node_modules,
+                 :symlink,
+                 skipped
+               ) do
           NPM.Install.Linker.link_local_packages(local_links, @node_modules)
         end
       end)
@@ -496,37 +522,93 @@ defmodule NPM do
     end
   end
 
-  defp expand_all_optional_deps(lockfile) do
-    Enum.reduce(lockfile, lockfile, fn {_name, entry}, acc ->
+  defp expand_all_optional_deps(lockfile, nested_lockfile) do
+    Enum.reduce(lockfile, {lockfile, nested_lockfile}, fn {name, entry}, acc ->
       entry
       |> Map.get(:optional_dependencies, %{})
-      |> Enum.reduce(acc, &expand_dependency/2)
+      |> Enum.reduce(acc, fn dependency, state ->
+        expand_dependency(dependency, "node_modules/#{name}", state)
+      end)
     end)
   end
 
-  defp expand_dependency({name, _range}, acc) when is_map_key(acc, name), do: acc
+  defp expand_dependency({name, range}, parent_location, {flat, nested} = state) do
+    if dependency_satisfied?(name, range, parent_location, flat, nested) do
+      state
+    else
+      case resolve_version(name, range) do
+        {:ok, version_str, info} ->
+          warn_age_heuristics(name, version_str, info)
 
-  defp expand_dependency({name, range}, acc) do
-    case resolve_version(name, range) do
-      {:ok, version_str, info} ->
-        warn_age_heuristics(name, version_str, info)
+          entry = %{
+            version: version_str,
+            integrity: info.dist.integrity,
+            tarball: info.dist.tarball,
+            dependencies: info.dependencies,
+            optional_dependencies: Map.get(info, :optional_dependencies, %{}),
+            has_install_script: Map.get(info, :has_install_script, false),
+            optional: true
+          }
 
-        entry = %{
-          version: version_str,
-          integrity: info.dist.integrity,
-          tarball: info.dist.tarball,
-          dependencies: info.dependencies,
-          optional_dependencies: Map.get(info, :optional_dependencies, %{}),
-          has_install_script: Map.get(info, :has_install_script, false)
-        }
+          {state, installed_location} =
+            put_expanded_dependency(name, entry, parent_location, flat, nested)
 
-        entry.dependencies
-        |> Map.merge(entry.optional_dependencies)
-        |> Enum.reduce(Map.put(acc, name, entry), &expand_dependency/2)
+          entry.dependencies
+          |> Map.merge(entry.optional_dependencies)
+          |> Enum.reduce(state, fn dependency, acc ->
+            expand_dependency(dependency, installed_location, acc)
+          end)
 
-      :error ->
-        acc
+        :error ->
+          state
+      end
     end
+  end
+
+  defp dependency_satisfied?(name, range, parent_location, flat, nested) do
+    parent_location
+    |> dependency_locations(name)
+    |> Enum.any?(fn location ->
+      case dependency_entry(location, name, flat, nested) do
+        nil -> false
+        entry -> lockfile_entry_satisfies_range?(entry, range)
+      end
+    end)
+  end
+
+  defp dependency_entry("node_modules/" <> rest = location, name, flat, nested) do
+    if rest == name, do: Map.get(flat, name), else: Map.get(nested, location)
+  end
+
+  defp put_expanded_dependency(name, entry, parent_location, flat, nested) do
+    if Map.has_key?(flat, name) do
+      location = "#{parent_location}/node_modules/#{name}"
+      {{flat, Map.put(nested, location, entry)}, location}
+    else
+      location = "node_modules/#{name}"
+      {{Map.put(flat, name, entry), nested}, location}
+    end
+  end
+
+  defp dependency_locations(parent_location, name) do
+    parent_segments = String.split(parent_location, "/", trim: true)
+    package_segments = String.split(name, "/", trim: true)
+
+    ancestors =
+      parent_segments
+      |> Enum.with_index()
+      |> Enum.filter(fn {segment, _index} -> segment == "node_modules" end)
+      |> Enum.map(fn {_segment, index} ->
+        Enum.take(parent_segments, index) ++ ["node_modules"] ++ package_segments
+      end)
+      |> Enum.reverse()
+
+    [
+      parent_segments ++ ["node_modules"] ++ package_segments
+      | ancestors
+    ]
+    |> Enum.map(&Enum.join(&1, "/"))
+    |> Enum.uniq()
   end
 
   defp resolve_version(name, range) do

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -76,8 +76,60 @@ defmodule NPM.Install.Linker do
     end)
   end
 
+  @doc false
+  @spec link_nested_lockfile(
+          %{String.t() => NPM.Lockfile.entry()},
+          String.t(),
+          strategy(),
+          MapSet.t(String.t())
+        ) :: :ok | {:error, term()}
+  def link_nested_lockfile(
+        nested_lockfile,
+        nm_dir \\ "node_modules",
+        strategy \\ default_strategy(),
+        flat_skipped \\ MapSet.new()
+      ) do
+    nested_lockfile
+    |> Enum.sort_by(fn {location, _entry} -> location_depth(location) end)
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn {location, entry}, {:ok, skipped_locations} ->
+      with {:ok, name} <- NPM.Lockfile.nested_package_name(location) do
+        cond do
+          nested_under_skipped?(location, flat_skipped, skipped_locations) ->
+            {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+          Map.get(entry, :optional, false) and
+              not platform_compatible?(name, entry.version) ->
+            {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+          true ->
+            case NPM.Cache.ensure(name, entry.version, entry.tarball, entry.integrity,
+                   optional?: Map.get(entry, :optional, false)
+                 ) do
+              {:ok, :missing_optional} ->
+                {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+              {:ok, _cache_result} ->
+                cache_path = NPM.Cache.package_dir(name, entry.version)
+                target = nested_target(nm_dir, location)
+                :ok = link_package(cache_path, target, strategy)
+                {:cont, {:ok, skipped_locations}}
+
+              {:error, reason} ->
+                {:halt, {:error, reason}}
+            end
+        end
+      else
+        :error -> {:halt, {:error, {:invalid_nested_package_location, location}}}
+      end
+    end)
+    |> case do
+      {:ok, _skipped_locations} -> :ok
+      error -> error
+    end
+  end
+
   defp populate_cache(lockfile, platform_skipped) do
-    platform_skipped = platform_skipped || platform_incompatible_packages(lockfile)
+    platform_skipped = platform_skipped || skipped_packages(lockfile)
 
     lockfile
     |> Enum.reject(fn {name, _} -> MapSet.member?(platform_skipped, name) end)
@@ -184,7 +236,11 @@ defmodule NPM.Install.Linker do
 
   @doc false
   @spec skipped_packages(resolved()) :: MapSet.t(String.t())
-  def skipped_packages(lockfile), do: platform_incompatible_packages(lockfile)
+  def skipped_packages(lockfile) do
+    lockfile
+    |> platform_incompatible_packages()
+    |> propagate_skipped_optional_descendants(lockfile)
+  end
 
   defp collect_all_packages(lockfile) do
     lockfile
@@ -357,11 +413,46 @@ defmodule NPM.Install.Linker do
         Map.keys(Map.get(entry, :optional_dependencies, %{}))
       end)
       |> MapSet.new()
+      |> then(fn names ->
+        Enum.reduce(lockfile, names, fn {name, entry}, acc ->
+          if Map.get(entry, :optional, false), do: MapSet.put(acc, name), else: acc
+        end)
+      end)
 
     lockfile
     |> Enum.filter(fn {name, _} -> MapSet.member?(optional_names, name) end)
     |> Enum.reject(fn {name, entry} -> platform_compatible?(name, entry.version) end)
     |> MapSet.new(fn {name, _} -> name end)
+  end
+
+  defp propagate_skipped_optional_descendants(skipped, lockfile) do
+    descendants =
+      skipped
+      |> Enum.flat_map(fn name ->
+        case Map.get(lockfile, name) do
+          nil ->
+            []
+
+          entry ->
+            Map.keys(entry.dependencies) ++
+              Map.keys(Map.get(entry, :optional_dependencies, %{}))
+        end
+      end)
+      |> Enum.filter(fn name ->
+        case Map.get(lockfile, name) do
+          nil -> false
+          entry -> Map.get(entry, :optional, false)
+        end
+      end)
+      |> MapSet.new()
+
+    expanded = MapSet.union(skipped, descendants)
+
+    if MapSet.equal?(expanded, skipped) do
+      skipped
+    else
+      propagate_skipped_optional_descendants(expanded, lockfile)
+    end
   end
 
   defp platform_compatible?(name, version) do
@@ -375,10 +466,33 @@ defmodule NPM.Install.Linker do
   end
 
   defp optional_dependency?(name, lockfile) do
-    Enum.any?(lockfile, fn {_pkg, entry} ->
-      Map.has_key?(Map.get(entry, :optional_dependencies, %{}), name)
-    end)
+    case Map.get(lockfile, name) do
+      %{optional: true} ->
+        true
+
+      _entry ->
+        Enum.any?(lockfile, fn {_pkg, entry} ->
+          Map.has_key?(Map.get(entry, :optional_dependencies, %{}), name)
+        end)
+    end
   end
+
+  defp nested_under_skipped?(location, flat_skipped, skipped_locations) do
+    Enum.any?(flat_skipped, fn name ->
+      String.starts_with?(location, "node_modules/#{name}/node_modules/")
+    end) or
+      Enum.any?(skipped_locations, fn skipped_location ->
+        String.starts_with?(location, "#{skipped_location}/node_modules/")
+      end)
+  end
+
+  defp nested_target(nm_dir, "node_modules/" <> relative_location) do
+    Path.join(nm_dir, relative_location)
+  end
+
+  defp nested_target(nm_dir, location), do: Path.join(nm_dir, location)
+
+  defp location_depth(location), do: location |> String.split("/") |> length()
 
   defp install_single_nested(_pkg, nil, _parent, _nm_dir, _strategy), do: :ok
 

--- a/apps/duskmoon_npm/lib/npm/lockfile.ex
+++ b/apps/duskmoon_npm/lib/npm/lockfile.ex
@@ -49,6 +49,28 @@ defmodule NPM.Lockfile do
     read_file(path)
   end
 
+  @doc false
+  @spec read_nested(String.t()) :: {:ok, %{String.t() => entry()}} | {:error, term()}
+  def read_nested(path \\ @default_path) do
+    case read_json(path) do
+      {:ok, %{"packages" => packages} = data} when is_map(packages) ->
+        if package_lock?(data, packages) do
+          parse_nested_package_lock_packages(packages)
+        else
+          {:ok, %{}}
+        end
+
+      {:ok, _data} ->
+        {:ok, %{}}
+
+      {:error, :enoent} ->
+        {:ok, %{}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @doc """
   Migrates the legacy `npm.lock` schema to `package-lock.json` v3.
 
@@ -217,22 +239,88 @@ defmodule NPM.Lockfile do
     |> Enum.flat_map(fn {location, info} ->
       with false <- Map.get(info, "link") == true,
            {:ok, name} <- package_name_from_location(location) do
-        [
-          {name,
-           %{
-             version: Map.get(info, "version", ""),
-             integrity: Map.get(info, "integrity", ""),
-             tarball: Map.get(info, "resolved", ""),
-             dependencies: Map.get(info, "dependencies", %{}),
-             optional_dependencies: optional_dependencies(info),
-             has_install_script: has_install_script?(info)
-           }}
-        ]
+        [{name, package_lock_entry_from_info(info)}]
       else
         _ -> []
       end
     end)
     |> Map.new()
+  end
+
+  defp parse_nested_package_lock_packages(packages) do
+    packages
+    |> Enum.reduce_while({:ok, %{}}, fn {location, info}, {:ok, acc} ->
+      cond do
+        not nested_package_location?(location) or Map.get(info, "link") == true ->
+          {:cont, {:ok, acc}}
+
+        match?({:ok, _name}, nested_package_name(location)) ->
+          {:cont, {:ok, Map.put(acc, location, package_lock_entry_from_info(info))}}
+
+        true ->
+          {:halt, {:error, {:invalid_nested_package_location, location}}}
+      end
+    end)
+  end
+
+  defp nested_package_location?(location) do
+    String.starts_with?(location, "node_modules/") and
+      location
+      |> String.split("/")
+      |> Enum.count(&(&1 == "node_modules"))
+      |> Kernel.>(1)
+  end
+
+  @doc false
+  @spec nested_package_name(String.t()) :: {:ok, String.t()} | :error
+  def nested_package_name(location) do
+    location
+    |> String.split("/", trim: false)
+    |> parse_nested_location([])
+  end
+
+  defp parse_nested_location(["node_modules" | rest], parents) do
+    with {:ok, name, remaining} <- take_package_name(rest) do
+      case remaining do
+        [] when parents != [] -> {:ok, name}
+        ["node_modules" | _] -> parse_nested_location(remaining, [name | parents])
+        _ -> :error
+      end
+    end
+  end
+
+  defp parse_nested_location(_segments, _parents), do: :error
+
+  defp take_package_name(["@" <> scope = scoped, package | rest]) do
+    name = "#{scoped}/#{package}"
+
+    if scope != "" and NPM.Scope.valid_name?(name) do
+      {:ok, name, rest}
+    else
+      :error
+    end
+  end
+
+  defp take_package_name([package | rest]) do
+    if NPM.Scope.valid_name?(package) do
+      {:ok, package, rest}
+    else
+      :error
+    end
+  end
+
+  defp take_package_name(_segments), do: :error
+
+  defp package_lock_entry_from_info(info) do
+    %{
+      version: Map.get(info, "version", ""),
+      integrity: Map.get(info, "integrity", ""),
+      tarball: Map.get(info, "resolved", ""),
+      dependencies: Map.get(info, "dependencies", %{}),
+      optional_dependencies: optional_dependencies(info),
+      has_install_script: has_install_script?(info)
+    }
+    |> maybe_mark_optional(info)
   end
 
   defp parse_legacy_dependencies(deps) do
@@ -402,6 +490,7 @@ defmodule NPM.Lockfile do
       empty_to_nil(Map.get(entry, :optional_dependencies, %{}))
     )
     |> maybe_put("hasInstallScript", if(Map.get(entry, :has_install_script, false), do: true))
+    |> maybe_put("optional", if(Map.get(entry, :optional, false), do: true))
   end
 
   defp put_workspace_links(packages, manifests) do
@@ -503,6 +592,14 @@ defmodule NPM.Lockfile do
 
   defp has_install_script?(info) do
     Map.get(info, "hasInstallScript") || Map.get(info, "has_install_script", false)
+  end
+
+  defp maybe_mark_optional(entry, info) do
+    if Map.get(info, "optional", false) do
+      Map.put(entry, :optional, true)
+    else
+      entry
+    end
   end
 
   defp legacy_path?(path), do: Path.basename(path) == @legacy_path

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -69,6 +69,73 @@ defmodule NPM.Install.LinkerTest do
              Linker.link(%{"blocked-pkg" => entry}, node_modules)
   end
 
+  test "skips optional descendants of a platform-incompatible package", %{
+    tmp_dir: tmp_dir
+  } do
+    root = "root-pkg"
+    optional = "other-platform-pkg"
+    descendant = "optional-descendant-pkg"
+    shared = "shared-required-pkg"
+    node_modules = Path.join(tmp_dir, "node_modules")
+
+    write_cached_package!(root, "1.0.0")
+    write_cached_package!(shared, "1.0.0")
+    put_incompatible_packument!(optional, "1.0.0")
+
+    lockfile = %{
+      root =>
+        lock_entry("1.0.0",
+          tarball: "https://registry.npmjs.org/root-pkg/-/root-pkg-1.0.0.tgz",
+          dependencies: %{shared => "1.0.0"},
+          optional_dependencies: %{optional => "1.0.0"}
+        ),
+      optional =>
+        lock_entry("1.0.0",
+          tarball: "https://blocked.example/other-platform-pkg-1.0.0.tgz",
+          dependencies: %{descendant => "1.0.0", shared => "1.0.0"},
+          optional: true
+        ),
+      descendant =>
+        lock_entry("1.0.0",
+          tarball: "https://blocked.example/optional-descendant-pkg-1.0.0.tgz",
+          optional: true
+        ),
+      shared =>
+        lock_entry("1.0.0",
+          tarball:
+            "https://registry.npmjs.org/shared-required-pkg/-/shared-required-pkg-1.0.0.tgz"
+        )
+    }
+
+    assert :ok = Linker.link(lockfile, node_modules)
+    assert File.exists?(Path.join([node_modules, root, "package.json"]))
+    assert File.exists?(Path.join([node_modules, shared, "package.json"]))
+    refute File.exists?(Path.join([node_modules, optional, "package.json"]))
+    refute File.exists?(Path.join([node_modules, descendant, "package.json"]))
+  end
+
+  test "rejects unsafe nested lockfile locations before filesystem access", %{
+    tmp_dir: tmp_dir
+  } do
+    node_modules = Path.join(tmp_dir, "node_modules")
+    entry = lock_entry("1.0.0")
+
+    unsafe_locations = [
+      "node_modules/parent/node_modules/..",
+      "node_modules/parent/node_modules/",
+      "node_modules/parent/extra/node_modules/child",
+      "node_modules/../../escaped/node_modules/child",
+      "/node_modules/parent/node_modules/child"
+    ]
+
+    Enum.each(unsafe_locations, fn location ->
+      assert {:error, {:invalid_nested_package_location, ^location}} =
+               Linker.link_nested_lockfile(%{location => entry}, node_modules)
+    end)
+
+    refute File.exists?(Path.join(tmp_dir, "escaped"))
+  end
+
   defp write_cached_package!(name, version) do
     cache_path = NPM.Cache.package_dir(name, version)
     File.mkdir_p!(cache_path)
@@ -83,16 +150,42 @@ defmodule NPM.Install.LinkerTest do
     cache_path
   end
 
-  defp lock_entry(version) do
+  defp lock_entry(version, opts \\ []) do
     %{
       version: version,
       integrity: "",
-      tarball: "https://registry.npmjs.org/cached-pkg/-/cached-pkg-#{version}.tgz",
-      dependencies: %{},
-      optional_dependencies: %{},
+      tarball:
+        Keyword.get(
+          opts,
+          :tarball,
+          "https://registry.npmjs.org/cached-pkg/-/cached-pkg-#{version}.tgz"
+        ),
+      dependencies: Keyword.get(opts, :dependencies, %{}),
+      optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
       has_install_script: false
     }
+    |> maybe_put_optional(Keyword.get(opts, :optional, false))
   end
+
+  defp put_incompatible_packument!(package, version) do
+    other_os = if NPM.Platform.current_os() == "darwin", do: "linux", else: "darwin"
+
+    NPM.PackumentCache.put(package, %{
+      name: package,
+      versions: %{
+        version => %{
+          os: [other_os],
+          cpu: [],
+          dependencies: %{},
+          optional_dependencies: %{},
+          dist: %{tarball: "", integrity: ""}
+        }
+      }
+    })
+  end
+
+  defp maybe_put_optional(entry, true), do: Map.put(entry, :optional, true)
+  defp maybe_put_optional(entry, false), do: entry
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)
   defp restore_app_env(key, value), do: Application.put_env(:duskmoon_npm, key, value)

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -138,6 +138,70 @@ defmodule NPM.InstallTest do
     refute File.exists?(Path.join([node_modules, optional_package, "package.json"]))
   end
 
+  test "locks required dependencies of optional packages excluded from resolution", %{
+    project_dir: project_dir
+  } do
+    package = "@duskmoon-dev/el-markdown-input"
+    version = "1.5.5"
+    current_mermaid = "mermaid-#{NPM.Platform.current_os()}-#{NPM.Platform.current_cpu()}"
+    other_mermaid = "mermaid-darwin-arm64"
+    parser = "@mermaid-js/parser"
+    parser_dependency = "langium"
+
+    other_mermaid =
+      if other_mermaid == current_mermaid, do: "mermaid-linux-x64", else: other_mermaid
+
+    Enum.each(
+      [
+        {package, version},
+        {current_mermaid, "11.15.0"},
+        {other_mermaid, "11.15.0"},
+        {parser, "1.1.1"},
+        {parser_dependency, "3.3.1"}
+      ],
+      fn {name, package_version} -> write_cached_package!(name, package_version) end
+    )
+
+    put_packument!(package, version,
+      optional_dependencies: %{
+        current_mermaid => "11.15.0",
+        other_mermaid => "11.15.0"
+      }
+    )
+
+    put_packument!(current_mermaid, "11.15.0")
+    put_packument!(other_mermaid, "11.15.0", dependencies: %{parser => "1.1.1"})
+    put_packument!(parser, "1.1.1", dependencies: %{parser_dependency => "3.3.1"})
+    put_packument!(parser_dependency, "3.3.1")
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "mermaid_optional_dependency_project",
+        "dependencies" => %{package => version}
+      })
+    )
+
+    capture_io(fn ->
+      assert :ok = NPM.install()
+    end)
+
+    assert {:ok, package_names} = NPM.Lockfile.all_package_names()
+
+    assert MapSet.new(package_names) ==
+             MapSet.new([
+               package,
+               current_mermaid,
+               other_mermaid,
+               parser,
+               parser_dependency
+             ])
+
+    capture_io(fn ->
+      assert :ok = NPM.install(frozen: true)
+    end)
+  end
+
   test "installs from workspace package using the workspace root", %{project_dir: project_dir} do
     package = "workspace-root-package"
     version = "1.0.0"

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -197,9 +197,94 @@ defmodule NPM.InstallTest do
                parser_dependency
              ])
 
+    assert {:ok, %{"packages" => packages}} = NPM.JSON.read_file("package-lock.json")
+
+    Enum.each([other_mermaid, parser, parser_dependency], fn name ->
+      assert packages["node_modules/#{name}"]["optional"] == true
+    end)
+
     capture_io(fn ->
       assert :ok = NPM.install(frozen: true)
     end)
+  end
+
+  test "nests marked 16 for optional mermaid beside flat marked 18", %{
+    project_dir: project_dir
+  } do
+    markdown = "@duskmoon-dev/el-markdown"
+    markdown_input = "@duskmoon-dev/el-markdown-input"
+    mermaid = "mermaid"
+    marked = "marked"
+
+    platform_mermaid =
+      "mermaid-#{NPM.Platform.current_os()}-#{NPM.Platform.current_cpu()}"
+
+    Enum.each(
+      [
+        {markdown, "1.5.3"},
+        {markdown_input, "1.5.3"},
+        {platform_mermaid, "1.0.0"},
+        {mermaid, "11.15.0"},
+        {marked, "16.3.0"},
+        {marked, "18.0.4"}
+      ],
+      fn {name, version} -> write_cached_package!(name, version) end
+    )
+
+    put_packument!(markdown, "1.5.3", dependencies: %{marked => "18.0.4"})
+
+    put_packument!(markdown_input, "1.5.3",
+      optional_dependencies: %{
+        mermaid => "11.15.0",
+        platform_mermaid => "1.0.0"
+      }
+    )
+
+    put_packument!(platform_mermaid, "1.0.0")
+    put_packument!(mermaid, "11.15.0", dependencies: %{marked => "^16.3.0"})
+
+    put_packument_versions!(marked, [
+      {"16.3.0", []},
+      {"18.0.4", []}
+    ])
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "marked_version_conflict_project",
+        "dependencies" => %{
+          markdown => "1.5.3",
+          markdown_input => "1.5.3"
+        }
+      })
+    )
+
+    capture_io(fn ->
+      assert :ok = NPM.install()
+    end)
+
+    assert {:ok, %{"packages" => packages}} = NPM.JSON.read_file("package-lock.json")
+    assert packages["node_modules/marked"]["version"] == "18.0.4"
+    assert packages["node_modules/mermaid"]["version"] == "11.15.0"
+    assert packages["node_modules/mermaid"]["optional"] == true
+
+    nested_marked = "node_modules/mermaid/node_modules/marked"
+    assert packages[nested_marked]["version"] == "16.3.0"
+    assert packages[nested_marked]["optional"] == true
+    assert installed_version!(nested_marked) == "16.3.0"
+
+    File.rm_rf!("node_modules")
+
+    mermaid
+    |> NPM.Cache.package_dir("11.15.0")
+    |> Path.join("node_modules")
+    |> File.rm_rf!()
+
+    capture_io(fn ->
+      assert :ok = NPM.install(frozen: true)
+    end)
+
+    assert installed_version!(nested_marked) == "16.3.0"
   end
 
   test "installs from workspace package using the workspace root", %{project_dir: project_dir} do
@@ -359,26 +444,32 @@ defmodule NPM.InstallTest do
   end
 
   defp put_packument!(package, version, opts \\ []) do
+    put_packument_versions!(package, [{version, opts}])
+  end
+
+  defp put_packument_versions!(package, versions) do
     NPM.PackumentCache.put(package, %{
       name: package,
-      versions: %{
-        version => %{
-          os: [],
-          cpu: [],
-          dependencies: Keyword.get(opts, :dependencies, %{}),
-          optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
-          peer_dependencies: %{},
-          peer_dependencies_meta: %{},
-          dist: %{
-            tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
-            integrity: ""
-          },
-          has_install_script: false,
-          deprecated: nil,
-          created_at: nil,
-          published_at: nil
-        }
-      }
+      versions:
+        Map.new(versions, fn {version, opts} ->
+          {version,
+           %{
+             os: [],
+             cpu: [],
+             dependencies: Keyword.get(opts, :dependencies, %{}),
+             optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
+             peer_dependencies: %{},
+             peer_dependencies_meta: %{},
+             dist: %{
+               tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
+               integrity: ""
+             },
+             has_install_script: false,
+             deprecated: nil,
+             created_at: nil,
+             published_at: nil
+           }}
+        end)
     })
   end
 
@@ -409,6 +500,13 @@ defmodule NPM.InstallTest do
     |> Path.join("package.json")
     |> NPM.JSON.read_file()
     |> then(fn {:ok, data} -> data end)
+  end
+
+  defp installed_version!(package_dir) do
+    package_dir
+    |> Path.join("package.json")
+    |> NPM.JSON.read_file()
+    |> then(fn {:ok, %{"version" => version}} -> version end)
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)

--- a/apps/duskmoon_npm/test/npm/lockfile_test.exs
+++ b/apps/duskmoon_npm/test/npm/lockfile_test.exs
@@ -116,19 +116,44 @@ defmodule NPM.LockfileTest do
              NPM.Lockfile.write(
                %{"parent" => lock_entry("1.0.0")},
                nested: %{
-                 "node_modules/parent/node_modules/nested" => lock_entry("2.0.0")
+                 "node_modules/parent/node_modules/nested" =>
+                   Map.put(lock_entry("2.0.0"), :optional, true)
                }
              )
 
     assert %{
              "packages" => %{
                "node_modules/parent" => %{"version" => "1.0.0"},
-               "node_modules/parent/node_modules/nested" => %{"version" => "2.0.0"}
+               "node_modules/parent/node_modules/nested" => %{
+                 "version" => "2.0.0",
+                 "optional" => true
+               }
              }
            } = read_json!("package-lock.json")
 
     assert {:ok, ["nested", "parent"]} = NPM.Lockfile.all_package_names()
     assert {:ok, %{"parent" => %{version: "1.0.0"}}} = NPM.Lockfile.read()
+
+    assert {:ok,
+            %{
+              "node_modules/parent/node_modules/nested" => %{
+                version: "2.0.0",
+                optional: true
+              }
+            }} = NPM.Lockfile.read_nested()
+  end
+
+  test "rejects unsafe nested package-lock locations while reading" do
+    location = "node_modules/parent/node_modules/.."
+
+    assert :ok =
+             NPM.Lockfile.write(
+               %{"parent" => lock_entry("1.0.0")},
+               nested: %{location => lock_entry("2.0.0")}
+             )
+
+    assert {:error, {:invalid_nested_package_location, ^location}} =
+             NPM.Lockfile.read_nested()
   end
 
   test "package-lock analyzer skips workspace links and nested packages" do


### PR DESCRIPTION
## Summary
- recursively expand optional package dependency graphs into complete flat and nested lock records
- read and install nested package-lock entries during frozen installs
- preserve optional-platform skip propagation and reject unsafe nested paths
- cover immediate frozen reinstall, nested version conflicts, lockfile parsing, and linker behavior

Fixes #103