### PR TITLE
fix: copy registry packages into node_modules

### DIFF
--- a/apps/duskmoon_npm/lib/mix/tasks/npm.config.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.config.ex
@@ -34,10 +34,5 @@ defmodule Mix.Tasks.Npm.Config do
     if System.get_env("NPM_TOKEN"), do: "token set", else: "none"
   end
 
-  defp link_strategy do
-    case :os.type() do
-      {:unix, _} -> "symlink"
-      _ -> "copy"
-    end
-  end
+  defp link_strategy, do: "copy"
 end

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -22,8 +22,9 @@ defmodule NPM do
       mix npm.remove lodash        # Remove a package
       mix npm.list                 # List installed packages
 
-  Packages are cached globally in `~/.npm_ex/cache/` and linked into
-  `node_modules/` via symlinks (macOS/Linux) or copies (Windows).
+  Packages are cached globally in `~/.npm_ex/cache/` and copied into
+  `node_modules/` so Node-compatible tools resolve sibling dependencies
+  from the installed dependency tree.
   """
 
   @node_modules "node_modules"
@@ -353,7 +354,7 @@ defmodule NPM do
 
     lockfile_intact? =
       Enum.all?(linkable_lockfile, fn {name, _entry} ->
-        Path.join([@node_modules, name, "package.json"]) |> File.exists?()
+        registry_package_intact?(name)
       end)
 
     local_links_intact? =
@@ -419,7 +420,7 @@ defmodule NPM do
 
     {link_us, result} =
       :timer.tc(fn ->
-        with :ok <- Linker.link(lockfile, @node_modules, :symlink, skipped) do
+        with :ok <- Linker.link(lockfile, @node_modules, :copy, skipped) do
           NPM.Install.Linker.link_local_packages(local_links, @node_modules)
         end
       end)
@@ -439,6 +440,13 @@ defmodule NPM do
 
   defp linkable_lockfile(lockfile, skipped) do
     Enum.reject(lockfile, fn {name, _entry} -> MapSet.member?(skipped, name) end)
+  end
+
+  defp registry_package_intact?(name) do
+    package_dir = Path.join(@node_modules, name)
+
+    match?({:ok, %File.Stat{type: :directory}}, File.lstat(package_dir)) and
+      File.exists?(Path.join(package_dir, "package.json"))
   end
 
   defp plural(map) do

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -3,8 +3,8 @@ defmodule NPM.Install.Linker do
   Creates `node_modules` from the global cache.
 
   Supports multiple linking strategies:
-  - `:symlink` (default) — symlinks from `node_modules/pkg` to cache
-  - `:copy` — full file copy
+  - `:copy` (default) — full file copy
+  - `:symlink` — symlinks from `node_modules/pkg` to cache
 
   Uses a hoisted layout where packages are placed as high in the tree
   as possible, only nesting when version conflicts occur.
@@ -407,7 +407,7 @@ defmodule NPM.Install.Linker do
   end
 
   defp default_strategy do
-    :symlink
+    :copy
   end
 
   defp cache_concurrency do

--- a/apps/duskmoon_npm/lib/npm/install/script_install.ex
+++ b/apps/duskmoon_npm/lib/npm/install/script_install.ex
@@ -107,7 +107,10 @@ defmodule NPM.Install.ScriptInstall do
     case NPM.Lockfile.read(lockfile_path) do
       {:ok, lockfile} when lockfile != %{} ->
         Enum.all?(lockfile, fn {name, _} ->
-          File.exists?(Path.join([nm_dir, name, "package.json"]))
+          package_dir = Path.join(nm_dir, name)
+
+          match?({:ok, %File.Stat{type: :directory}}, File.lstat(package_dir)) and
+            File.exists?(Path.join(package_dir, "package.json"))
         end)
 
       _ ->

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -2,6 +2,7 @@ defmodule NPM.Install.LinkerTest do
   use ExUnit.Case, async: false
 
   alias NPM.Install.Linker
+  alias NPM.Resolution.PackageResolver
 
   setup do
     old_cache_dir = Application.get_env(:duskmoon_npm, :cache_dir)
@@ -45,12 +46,53 @@ defmodule NPM.Install.LinkerTest do
              )
   end
 
-  test "links cached packages with symlinks by default", %{tmp_dir: tmp_dir} do
-    cache_path = write_cached_package!("cached-pkg", "1.0.0")
+  test "copies cached packages so sibling dependencies resolve from node_modules", %{
+    tmp_dir: tmp_dir
+  } do
+    importer = "importer-pkg"
+    sibling = "sibling-pkg"
+    importer_cache_path = write_cached_package!(importer, "1.0.0")
+    sibling_cache_path = write_cached_package!(sibling, "2.0.0")
     node_modules = Path.join(tmp_dir, "node_modules")
 
-    assert :ok = Linker.link(%{"cached-pkg" => lock_entry("1.0.0")}, node_modules)
-    assert {:ok, ^cache_path} = File.read_link(Path.join(node_modules, "cached-pkg"))
+    File.write!(
+      Path.join(importer_cache_path, "index.js"),
+      ~s[module.exports = require("#{sibling}");]
+    )
+
+    File.write!(Path.join(sibling_cache_path, "index.js"), ~s[module.exports = "resolved";])
+
+    lockfile = %{
+      importer => %{
+        lock_entry(importer, "1.0.0")
+        | dependencies: %{sibling => "2.0.0"}
+      },
+      sibling => lock_entry(sibling, "2.0.0")
+    }
+
+    assert :ok = Linker.link(lockfile, node_modules)
+
+    installed_importer = Path.join(node_modules, importer)
+    installed_sibling = Path.join(node_modules, sibling)
+
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_importer)
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_sibling)
+    assert File.read!(Path.join(installed_importer, "index.js")) =~ sibling
+
+    assert File.read!(Path.join(installed_importer, "package.json")) ==
+             File.read!(Path.join(importer_cache_path, "package.json"))
+
+    assert File.read!(Path.join(installed_sibling, "package.json")) ==
+             File.read!(Path.join(sibling_cache_path, "package.json"))
+
+    canonical_importer =
+      case File.read_link(installed_importer) do
+        {:ok, target} -> Path.expand(target, Path.dirname(installed_importer))
+        {:error, :einval} -> installed_importer
+      end
+
+    assert {:ok, sibling_entry} = PackageResolver.resolve(sibling, canonical_importer)
+    assert sibling_entry == Path.join(installed_sibling, "index.js")
   end
 
   test "returns cache population errors directly", %{tmp_dir: tmp_dir} do
@@ -83,11 +125,11 @@ defmodule NPM.Install.LinkerTest do
     cache_path
   end
 
-  defp lock_entry(version) do
+  defp lock_entry(package, version) do
     %{
       version: version,
       integrity: "",
-      tarball: "https://registry.npmjs.org/cached-pkg/-/cached-pkg-#{version}.tgz",
+      tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
       dependencies: %{},
       optional_dependencies: %{},
       has_install_script: false

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -53,7 +53,39 @@ defmodule NPM.InstallTest do
     assert output =~ "Installing from current package-lock.json."
     assert output =~ "Installed 1 package"
     assert output =~ "* #{package} #{version} (npm registry)"
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+  end
+
+  test "replaces cache symlinks left by earlier installs", %{project_dir: project_dir} do
+    package = "legacy-symlink-package"
+    version = "1.0.0"
+    cache_path = write_cached_package!(package, version)
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "legacy_symlink_project",
+        "dependencies" => %{package => version}
+      })
+    )
+
+    assert :ok = NPM.Lockfile.write(%{package => lock_entry(package, version)})
+
+    installed_path = Path.join([project_dir, "node_modules", package])
+    File.mkdir_p!(Path.dirname(installed_path))
+    File.ln_s!(cache_path, installed_path)
+
+    output =
+      capture_io(fn ->
+        assert :ok = NPM.install()
+      end)
+
+    assert output =~ "Installing from current package-lock.json."
+    assert_copied_package(cache_path, installed_path)
   end
 
   test "re-resolves a lockfile with missing transitive package records", %{
@@ -93,7 +125,7 @@ defmodule NPM.InstallTest do
       end)
 
     refute output =~ "Already up to date."
-    assert {:ok, ^dependency_cache_path} = File.read_link(Path.join(node_modules, dependency))
+    assert_copied_package(dependency_cache_path, Path.join(node_modules, dependency))
 
     assert {:ok, lockfile} = NPM.Lockfile.read()
     assert Map.has_key?(lockfile, dependency)
@@ -127,7 +159,7 @@ defmodule NPM.InstallTest do
 
     node_modules = Path.join(project_dir, "node_modules")
     File.mkdir_p!(node_modules)
-    File.ln_s!(cache_path, Path.join(node_modules, package))
+    File.cp_r!(cache_path, Path.join(node_modules, package))
 
     output =
       capture_io(fn ->
@@ -165,7 +197,12 @@ defmodule NPM.InstallTest do
       end)
 
     assert output =~ "Installing from current package-lock.json."
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+
     assert {:ok, ^app_dir} = File.read_link(Path.join([project_dir, "node_modules", "web"]))
     assert File.exists?(Path.join(project_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "package-lock.json"))
@@ -207,7 +244,7 @@ defmodule NPM.InstallTest do
       end)
 
     refute output =~ "Already up to date."
-    assert {:ok, ^new_cache_path} = File.read_link(Path.join(node_modules, package))
+    assert_copied_package(new_cache_path, Path.join(node_modules, package))
     assert {:ok, ^app_dir} = File.read_link(Path.join([node_modules, "web"]))
 
     assert {:ok, lockfile} = NPM.Lockfile.read(Path.join(project_dir, "package-lock.json"))
@@ -242,7 +279,12 @@ defmodule NPM.InstallTest do
 
     assert %{"dependencies" => %{^package => ^version}} = read_package!(app_dir)
     refute Map.has_key?(read_package!(project_dir), "dependencies")
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+
     assert File.exists?(Path.join(project_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "node_modules"))
@@ -345,6 +387,13 @@ defmodule NPM.InstallTest do
     |> Path.join("package.json")
     |> NPM.JSON.read_file()
     |> then(fn {:ok, data} -> data end)
+  end
+
+  defp assert_copied_package(cache_path, installed_path) do
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_path)
+
+    assert File.read!(Path.join(installed_path, "package.json")) ==
+             File.read!(Path.join(cache_path, "package.json"))
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)


### PR DESCRIPTION
## Summary
- copy registry packages into node_modules so canonical importer paths retain sibling dependency resolution
- keep workspace packages as local links while detecting and replacing legacy cache symlinks
- make copy the reported install strategy and cover sibling resolution plus reinstall behavior

Fixes #102