### PR TITLE
fix: resolve outstanding internal requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -135,7 +135,7 @@ jobs:
               {:duskmoon_oxide, "~> ${VERSION}"},
               {:duskmoon_quickbeam, "~> ${VERSION}"},
               {:duskmoon_bundler_runtime, "~> ${VERSION}"},
-              {:duskmoon_bundler, "~> ${VERSION}", runtime: Mix.env() == :dev},
+              {:duskmoon_bundler, "~> ${VERSION}", runtime: Mix.env() in [:dev, :test]},
               {:phoenix_duskmoon, "~> ${VERSION}"}
             ]
           end
@@ -153,7 +153,7 @@ jobs:
               {:duskmoon_oxide, path: "${APP_ROOT}/duskmoon_oxide"},
               {:duskmoon_quickbeam, path: "${APP_ROOT}/duskmoon_quickbeam"},
               {:duskmoon_bundler_runtime, path: "${APP_ROOT}/duskmoon_bundler_runtime"},
-              {:duskmoon_bundler, path: "${APP_ROOT}/duskmoon_bundler", runtime: Mix.env() == :dev},
+              {:duskmoon_bundler, path: "${APP_ROOT}/duskmoon_bundler", runtime: Mix.env() in [:dev, :test]},
               {:phoenix_duskmoon, path: "${APP_ROOT}/phoenix_duskmoon"}
             ]
           end

--- a/apps/duskmoon_bundler/CHANGELOG.md
+++ b/apps/duskmoon_bundler/CHANGELOG.md
@@ -8,11 +8,12 @@
 
 ### Changed
 - Production manifests now include `manifest_version: 1` and an `entries` object while the runtime reader remains compatible with legacy flat manifests.
-- Phoenix projects should depend on both `:duskmoon_bundler_runtime` and `:duskmoon_bundler`, with `:duskmoon_bundler` configured as `runtime: Mix.env() == :dev`.
+- Phoenix projects should depend on both `:duskmoon_bundler_runtime` and `:duskmoon_bundler`, with `:duskmoon_bundler` configured as `runtime: Mix.env() in [:dev, :test]`.
 - HMR websocket messages (`ping`, `pong`, `update`, `error`) now flow through `DuskmoonBundler.HMR.Message`, which uses `JSONCodec` for struct<->JSON (de)serialization with `Jason` performing the final binary encoding.
 - Added `json_codec` as a runtime dependency.
 
 ### Fixed
+- Generated installs now start `:duskmoon_bundler` in test, ensuring endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 - HMR websocket no longer drops idle connections after 60 seconds. The browser client now sends a periodic `{"type":"ping"}` heartbeat, and the server replies with `{"type":"pong"}`, preventing Bandit's websocket `read_timeout` from closing an otherwise idle socket. The client also tracks pongs and force-reconnects if the link goes half-open. This eliminates the spurious `[DuskmoonBundler] Disconnected. Reconnecting...` console noise observed on long-lived demo/dev pages with no file changes.
 
 ## 0.14.6

--- a/apps/duskmoon_bundler/README.md
+++ b/apps/duskmoon_bundler/README.md
@@ -35,7 +35,7 @@ Or add the dep manually:
 def deps do
   [
     {:duskmoon_bundler_runtime, "~> 9.7"},
-    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
   ]
 end
 ```

--- a/apps/duskmoon_bundler/guides/deployment/production-builds.md
+++ b/apps/duskmoon_bundler/guides/deployment/production-builds.md
@@ -28,7 +28,7 @@ Production builds run the same framework/plugin compilation pipeline as the dev 
 - writes a manifest that Phoenix can use for digested asset paths and chunk preload metadata
 - optionally copies a Vite-style public directory to the static root without transforming files
 
-Phoenix releases that call `DuskmoonBundler.static_path/2` or `DuskmoonBundler.Preload.tags/2` only need `:duskmoon_bundler_runtime` at runtime. Keep `:duskmoon_bundler` available for build aliases with `runtime: Mix.env() == :dev`; do not mark it `only: :dev`, because asset deploy aliases often run under `MIX_ENV=prod`.
+Phoenix releases that call `DuskmoonBundler.static_path/2` or `DuskmoonBundler.Preload.tags/2` only need `:duskmoon_bundler_runtime` at runtime. Keep `:duskmoon_bundler` available for build aliases with `runtime: Mix.env() in [:dev, :test]`; do not mark it `only: :dev`, because asset deploy aliases often run under `MIX_ENV=prod`. Starting the app in test ensures endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 
 ## Public files in Phoenix apps
 

--- a/apps/duskmoon_bundler/guides/introduction/getting-started.md
+++ b/apps/duskmoon_bundler/guides/introduction/getting-started.md
@@ -7,7 +7,7 @@ mix igniter.install duskmoon_bundler
 ```
 
 The installer:
-- Adds `{:duskmoon_bundler_runtime, "~> 9.7"}` and `{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}` to `mix.exs`
+- Adds `{:duskmoon_bundler_runtime, "~> 9.7"}` and `{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}` to `mix.exs`
 - Configures build settings in `config/config.exs`
 - Adds format and lint config to `config/config.exs`
 - Adds `DuskmoonBundler.Formatter` plugin to `.formatter.exs`
@@ -30,12 +30,12 @@ Add DuskmoonBundler to your dependencies:
 def deps do
   [
     {:duskmoon_bundler_runtime, "~> 9.7"},
-    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
   ]
 end
 ```
 
-Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option keeps build/dev tooling out of production releases while still making Mix tasks available.
+Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option starts the DevServer and its cache/HMR supervision tree in development and code-reloading tests, keeps build/dev tooling out of production releases, and still makes Mix tasks available.
 
 ### Build Configuration
 

--- a/apps/duskmoon_bundler/guides/migration/from-esbuild.md
+++ b/apps/duskmoon_bundler/guides/migration/from-esbuild.md
@@ -23,10 +23,10 @@ Add:
 
 ```elixir
 {:duskmoon_bundler_runtime, "~> 9.7"},
-{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
 ```
 
-Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option keeps the build/dev app out of production releases.
+Do not use `only: :dev` for `:duskmoon_bundler`; production asset build aliases may run under `MIX_ENV=prod`. The `runtime:` option starts the DevServer and its cache/HMR supervision tree in development and code-reloading tests while keeping the build/dev app out of production releases.
 
 ### 2. Replace Config
 

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/runtime/installer.ex
@@ -112,7 +112,14 @@ defmodule DuskmoonBundler.JS.Runtime.Installer do
   end
 
   defp with_lock(id, fun) do
-    :global.trans({__MODULE__, id}, fun, [node()], :infinity)
+    :global.trans(lock_id(id), fun, [node()], :infinity)
+  end
+
+  @doc false
+  def __lock_id__(id, requester \\ self()), do: lock_id(id, requester)
+
+  defp lock_id(id, requester \\ self()) do
+    {{__MODULE__, Path.expand(id)}, requester}
   end
 
   defp metadata_mismatch?(metadata_path, signature) do

--- a/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.install.ex
+++ b/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.install.ex
@@ -73,7 +73,7 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp add_duskmoon_deps(igniter) do
-      runtime_setting = Sourceror.parse_string!("Mix.env() == :dev")
+      runtime_setting = Sourceror.parse_string!("Mix.env() in [:dev, :test]")
 
       igniter
       |> ProjectDeps.add_dep({:duskmoon_bundler_runtime, "~> 9.7"}, on_exists: :skip)

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/js/runtime/installer_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/js/runtime/installer_test.exs
@@ -37,6 +37,30 @@ defmodule DuskmoonBundler.JS.Runtime.InstallerTest do
     assert second["packages"] == %{"left-pad" => "1.3.0"}
   end
 
+  test "uses the install directory as the lock resource and the process as requester", %{
+    tmp_dir: tmp_dir
+  } do
+    requester = make_ref()
+
+    assert Installer.__lock_id__(tmp_dir, requester) ==
+             {{Installer, Path.expand(tmp_dir)}, requester}
+  end
+
+  test "serializes concurrent forced installs into the same directory", %{tmp_dir: tmp_dir} do
+    1..16
+    |> Task.async_stream(
+      fn _ -> Installer.install!(%{}, install_dir: tmp_dir, force: true) end,
+      max_concurrency: 16,
+      ordered: false,
+      timeout: 30_000
+    )
+    |> Enum.each(fn
+      {:ok, %{install_dir: ^tmp_dir}} -> :ok
+    end)
+
+    assert read_metadata(tmp_dir)["packages"] == %{}
+  end
+
   defp read_metadata(install_dir) do
     install_dir
     |> Path.join("duskmoon-bundler-runtime.json")

--- a/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.install_test.exs
+++ b/apps/duskmoon_bundler/test/mix/tasks/duskmoon_bundler.install_test.exs
@@ -123,7 +123,10 @@ defmodule DuskmoonBundler.InstallTest do
         |> Rewrite.Source.get(:content)
 
       assert mix_content =~ ~s({:duskmoon_bundler_runtime, "~> 9.7"})
-      assert mix_content =~ "{:duskmoon_bundler, \"~> 9.7\", runtime: Mix.env() == :dev}"
+
+      assert mix_content =~
+               "{:duskmoon_bundler, \"~> 9.7\", runtime: Mix.env() in [:dev, :test]}"
+
       assert mix_content =~ ~s("assets.setup": [])
       assert mix_content =~ ~s("assets.build": ["compile", "duskmoon_bundler.build --tailwind"])
 

--- a/apps/duskmoon_bundler_runtime/README.md
+++ b/apps/duskmoon_bundler_runtime/README.md
@@ -13,7 +13,7 @@ Development and production asset builds should include the build package too:
 
 ```elixir
 {:duskmoon_bundler_runtime, "~> 9.7"},
-{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+{:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
 ```
 
 The runtime package owns the public template-facing APIs:

--- a/apps/duskmoon_npm/lib/mix/tasks/npm.ci.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.ci.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Npm.Ci do
 
   @impl true
   def run([]) do
+    Application.ensure_all_started(:ssl)
     Application.ensure_all_started(:req)
 
     case NPM.install(frozen: true) do

--- a/apps/duskmoon_npm/lib/mix/tasks/npm.config.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.config.ex
@@ -34,10 +34,5 @@ defmodule Mix.Tasks.Npm.Config do
     if System.get_env("NPM_TOKEN"), do: "token set", else: "none"
   end
 
-  defp link_strategy do
-    case :os.type() do
-      {:unix, _} -> "symlink"
-      _ -> "copy"
-    end
-  end
+  defp link_strategy, do: "copy"
 end

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -362,7 +362,25 @@ defmodule NPM do
         Path.join([@node_modules, name, "package.json"]) |> File.exists?()
       end)
 
-    lockfile_intact? and local_links_intact?
+    nested_lockfile_intact? =
+      case NPM.Lockfile.read_nested() do
+        {:ok, nested_lockfile} ->
+          Enum.all?(nested_lockfile, fn {location, _entry} ->
+            nested_location_skipped?(location, skipped) or
+              Path.join(location, "package.json") |> File.exists?()
+          end)
+
+        {:error, _reason} ->
+          false
+      end
+
+    lockfile_intact? and nested_lockfile_intact? and local_links_intact?
+  end
+
+  defp nested_location_skipped?(location, skipped) do
+    Enum.any?(skipped, fn name ->
+      String.starts_with?(location, "node_modules/#{name}/node_modules/")
+    end)
   end
 
   defp resolve_and_install(deps, old_lockfile, local_links) do
@@ -384,12 +402,12 @@ defmodule NPM do
           Mix.shell().info("  (#{map_size(nested_info)} packages with nested versions)")
         end
 
-        lockfile = build_lockfile(flat)
-        lockfile = expand_all_optional_deps(lockfile)
         nested_lockfile = build_nested_lockfile(nested_info, flat)
+        lockfile = build_lockfile(flat)
+        {lockfile, nested_lockfile} = expand_all_optional_deps(lockfile, nested_lockfile)
         print_lockfile_diff(old_lockfile, lockfile)
         NPM.Lockfile.write(lockfile, nested: nested_lockfile)
-        link_and_nest(lockfile, nested_info, flat, local_links)
+        link_from_lockfile(lockfile, local_links, nested_lockfile)
 
       {:error, message} ->
         Mix.shell().error("Resolution failed:\n#{message}")
@@ -397,14 +415,15 @@ defmodule NPM do
     end
   end
 
-  defp link_and_nest(lockfile, nested_info, flat, local_links) do
-    with :ok <- link_from_lockfile(lockfile, local_links) do
-      if nested_info != %{}, do: Linker.link_nested(nested_info, flat, @node_modules)
-      :ok
+  defp link_from_lockfile(lockfile, local_links, nested_lockfile \\ :read)
+
+  defp link_from_lockfile(lockfile, local_links, :read) do
+    with {:ok, nested_lockfile} <- NPM.Lockfile.read_nested() do
+      link_from_lockfile(lockfile, local_links, nested_lockfile)
     end
   end
 
-  defp link_from_lockfile(lockfile, local_links) do
+  defp link_from_lockfile(lockfile, local_links, nested_lockfile) do
     skipped = Linker.skipped_packages(lockfile)
     linkable_lockfile = linkable_lockfile(lockfile, skipped)
     total = length(linkable_lockfile)
@@ -420,7 +439,14 @@ defmodule NPM do
 
     {link_us, result} =
       :timer.tc(fn ->
-        with :ok <- Linker.link(lockfile, @node_modules, :copy, skipped) do
+        with :ok <- Linker.link(lockfile, @node_modules, :copy, skipped),
+             :ok <-
+               Linker.link_nested_lockfile(
+                 nested_lockfile,
+                 @node_modules,
+                 :copy,
+                 skipped
+               ) do
           NPM.Install.Linker.link_local_packages(local_links, @node_modules)
         end
       end)
@@ -504,37 +530,93 @@ defmodule NPM do
     end
   end
 
-  defp expand_all_optional_deps(lockfile) do
-    Enum.reduce(lockfile, lockfile, fn {_name, entry}, acc ->
+  defp expand_all_optional_deps(lockfile, nested_lockfile) do
+    Enum.reduce(lockfile, {lockfile, nested_lockfile}, fn {name, entry}, acc ->
       entry
       |> Map.get(:optional_dependencies, %{})
-      |> Enum.reduce(acc, &expand_dependency/2)
+      |> Enum.reduce(acc, fn dependency, state ->
+        expand_dependency(dependency, "node_modules/#{name}", state)
+      end)
     end)
   end
 
-  defp expand_dependency({name, _range}, acc) when is_map_key(acc, name), do: acc
+  defp expand_dependency({name, range}, parent_location, {flat, nested} = state) do
+    if dependency_satisfied?(name, range, parent_location, flat, nested) do
+      state
+    else
+      case resolve_version(name, range) do
+        {:ok, version_str, info} ->
+          warn_age_heuristics(name, version_str, info)
 
-  defp expand_dependency({name, range}, acc) do
-    case resolve_version(name, range) do
-      {:ok, version_str, info} ->
-        warn_age_heuristics(name, version_str, info)
+          entry = %{
+            version: version_str,
+            integrity: info.dist.integrity,
+            tarball: info.dist.tarball,
+            dependencies: info.dependencies,
+            optional_dependencies: Map.get(info, :optional_dependencies, %{}),
+            has_install_script: Map.get(info, :has_install_script, false),
+            optional: true
+          }
 
-        entry = %{
-          version: version_str,
-          integrity: info.dist.integrity,
-          tarball: info.dist.tarball,
-          dependencies: info.dependencies,
-          optional_dependencies: Map.get(info, :optional_dependencies, %{}),
-          has_install_script: Map.get(info, :has_install_script, false)
-        }
+          {state, installed_location} =
+            put_expanded_dependency(name, entry, parent_location, flat, nested)
 
-        entry.dependencies
-        |> Map.merge(entry.optional_dependencies)
-        |> Enum.reduce(Map.put(acc, name, entry), &expand_dependency/2)
+          entry.dependencies
+          |> Map.merge(entry.optional_dependencies)
+          |> Enum.reduce(state, fn dependency, acc ->
+            expand_dependency(dependency, installed_location, acc)
+          end)
 
-      :error ->
-        acc
+        :error ->
+          state
+      end
     end
+  end
+
+  defp dependency_satisfied?(name, range, parent_location, flat, nested) do
+    parent_location
+    |> dependency_locations(name)
+    |> Enum.any?(fn location ->
+      case dependency_entry(location, name, flat, nested) do
+        nil -> false
+        entry -> lockfile_entry_satisfies_range?(entry, range)
+      end
+    end)
+  end
+
+  defp dependency_entry("node_modules/" <> rest = location, name, flat, nested) do
+    if rest == name, do: Map.get(flat, name), else: Map.get(nested, location)
+  end
+
+  defp put_expanded_dependency(name, entry, parent_location, flat, nested) do
+    if Map.has_key?(flat, name) do
+      location = "#{parent_location}/node_modules/#{name}"
+      {{flat, Map.put(nested, location, entry)}, location}
+    else
+      location = "node_modules/#{name}"
+      {{Map.put(flat, name, entry), nested}, location}
+    end
+  end
+
+  defp dependency_locations(parent_location, name) do
+    parent_segments = String.split(parent_location, "/", trim: true)
+    package_segments = String.split(name, "/", trim: true)
+
+    ancestors =
+      parent_segments
+      |> Enum.with_index()
+      |> Enum.filter(fn {segment, _index} -> segment == "node_modules" end)
+      |> Enum.map(fn {_segment, index} ->
+        Enum.take(parent_segments, index) ++ ["node_modules"] ++ package_segments
+      end)
+      |> Enum.reverse()
+
+    [
+      parent_segments ++ ["node_modules"] ++ package_segments
+      | ancestors
+    ]
+    |> Enum.map(&Enum.join(&1, "/"))
+    |> Enum.uniq()
   end
 
   defp resolve_version(name, range) do

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -508,25 +508,29 @@ defmodule NPM do
     Enum.reduce(lockfile, lockfile, fn {_name, entry}, acc ->
       entry
       |> Map.get(:optional_dependencies, %{})
-      |> Enum.reduce(acc, &maybe_add_optional_dep/2)
+      |> Enum.reduce(acc, &expand_dependency/2)
     end)
   end
 
-  defp maybe_add_optional_dep({name, _range}, acc) when is_map_key(acc, name), do: acc
+  defp expand_dependency({name, _range}, acc) when is_map_key(acc, name), do: acc
 
-  defp maybe_add_optional_dep({name, range}, acc) do
+  defp expand_dependency({name, range}, acc) do
     case resolve_version(name, range) do
       {:ok, version_str, info} ->
         warn_age_heuristics(name, version_str, info)
 
-        Map.put(acc, name, %{
+        entry = %{
           version: version_str,
           integrity: info.dist.integrity,
           tarball: info.dist.tarball,
           dependencies: info.dependencies,
           optional_dependencies: Map.get(info, :optional_dependencies, %{}),
           has_install_script: Map.get(info, :has_install_script, false)
-        })
+        }
+
+        entry.dependencies
+        |> Map.merge(entry.optional_dependencies)
+        |> Enum.reduce(Map.put(acc, name, entry), &expand_dependency/2)
 
       :error ->
         acc

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -22,8 +22,9 @@ defmodule NPM do
       mix npm.remove lodash        # Remove a package
       mix npm.list                 # List installed packages
 
-  Packages are cached globally in `~/.npm_ex/cache/` and linked into
-  `node_modules/` via symlinks (macOS/Linux) or copies (Windows).
+  Packages are cached globally in `~/.npm_ex/cache/` and copied into
+  `node_modules/` so Node-compatible tools resolve sibling dependencies
+  from the installed dependency tree.
   """
 
   @node_modules "node_modules"
@@ -353,7 +354,7 @@ defmodule NPM do
 
     lockfile_intact? =
       Enum.all?(linkable_lockfile, fn {name, _entry} ->
-        Path.join([@node_modules, name, "package.json"]) |> File.exists?()
+        registry_package_intact?(name)
       end)
 
     local_links_intact? =
@@ -419,7 +420,7 @@ defmodule NPM do
 
     {link_us, result} =
       :timer.tc(fn ->
-        with :ok <- Linker.link(lockfile, @node_modules, :symlink, skipped) do
+        with :ok <- Linker.link(lockfile, @node_modules, :copy, skipped) do
           NPM.Install.Linker.link_local_packages(local_links, @node_modules)
         end
       end)
@@ -439,6 +440,13 @@ defmodule NPM do
 
   defp linkable_lockfile(lockfile, skipped) do
     Enum.reject(lockfile, fn {name, _entry} -> MapSet.member?(skipped, name) end)
+  end
+
+  defp registry_package_intact?(name) do
+    package_dir = Path.join(@node_modules, name)
+
+    match?({:ok, %File.Stat{type: :directory}}, File.lstat(package_dir)) and
+      File.exists?(Path.join(package_dir, "package.json"))
   end
 
   defp plural(map) do

--- a/apps/duskmoon_npm/lib/npm/cache.ex
+++ b/apps/duskmoon_npm/lib/npm/cache.ex
@@ -131,7 +131,16 @@ defmodule NPM.Cache do
   end
 
   defp with_lock(name, version, fun) do
-    :global.trans({__MODULE__, {name, version}}, fun, [node()], :infinity)
+    :global.trans(lock_id(name, version), fun, [node()], :infinity)
+  end
+
+  @doc false
+  def __lock_id__(name, version, requester \\ self()) do
+    lock_id(name, version, requester)
+  end
+
+  defp lock_id(name, version, requester \\ self()) do
+    {{__MODULE__, name, version}, requester}
   end
 
   defp write_complete_marker!(dest) do

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -76,8 +76,60 @@ defmodule NPM.Install.Linker do
     end)
   end
 
+  @doc false
+  @spec link_nested_lockfile(
+          %{String.t() => NPM.Lockfile.entry()},
+          String.t(),
+          strategy(),
+          MapSet.t(String.t())
+        ) :: :ok | {:error, term()}
+  def link_nested_lockfile(
+        nested_lockfile,
+        nm_dir \\ "node_modules",
+        strategy \\ default_strategy(),
+        flat_skipped \\ MapSet.new()
+      ) do
+    nested_lockfile
+    |> Enum.sort_by(fn {location, _entry} -> location_depth(location) end)
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn {location, entry}, {:ok, skipped_locations} ->
+      with {:ok, name} <- NPM.Lockfile.nested_package_name(location) do
+        cond do
+          nested_under_skipped?(location, flat_skipped, skipped_locations) ->
+            {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+          Map.get(entry, :optional, false) and
+              not platform_compatible?(name, entry.version) ->
+            {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+          true ->
+            case NPM.Cache.ensure(name, entry.version, entry.tarball, entry.integrity,
+                   optional?: Map.get(entry, :optional, false)
+                 ) do
+              {:ok, :missing_optional} ->
+                {:cont, {:ok, MapSet.put(skipped_locations, location)}}
+
+              {:ok, _cache_result} ->
+                cache_path = NPM.Cache.package_dir(name, entry.version)
+                target = nested_target(nm_dir, location)
+                :ok = link_package(cache_path, target, strategy)
+                {:cont, {:ok, skipped_locations}}
+
+              {:error, reason} ->
+                {:halt, {:error, reason}}
+            end
+        end
+      else
+        :error -> {:halt, {:error, {:invalid_nested_package_location, location}}}
+      end
+    end)
+    |> case do
+      {:ok, _skipped_locations} -> :ok
+      error -> error
+    end
+  end
+
   defp populate_cache(lockfile, platform_skipped) do
-    platform_skipped = platform_skipped || platform_incompatible_packages(lockfile)
+    platform_skipped = platform_skipped || skipped_packages(lockfile)
 
     lockfile
     |> Enum.reject(fn {name, _} -> MapSet.member?(platform_skipped, name) end)
@@ -184,7 +236,11 @@ defmodule NPM.Install.Linker do
 
   @doc false
   @spec skipped_packages(resolved()) :: MapSet.t(String.t())
-  def skipped_packages(lockfile), do: platform_incompatible_packages(lockfile)
+  def skipped_packages(lockfile) do
+    lockfile
+    |> platform_incompatible_packages()
+    |> propagate_skipped_optional_descendants(lockfile)
+  end
 
   defp collect_all_packages(lockfile) do
     lockfile
@@ -357,11 +413,46 @@ defmodule NPM.Install.Linker do
         Map.keys(Map.get(entry, :optional_dependencies, %{}))
       end)
       |> MapSet.new()
+      |> then(fn names ->
+        Enum.reduce(lockfile, names, fn {name, entry}, acc ->
+          if Map.get(entry, :optional, false), do: MapSet.put(acc, name), else: acc
+        end)
+      end)
 
     lockfile
     |> Enum.filter(fn {name, _} -> MapSet.member?(optional_names, name) end)
     |> Enum.reject(fn {name, entry} -> platform_compatible?(name, entry.version) end)
     |> MapSet.new(fn {name, _} -> name end)
+  end
+
+  defp propagate_skipped_optional_descendants(skipped, lockfile) do
+    descendants =
+      skipped
+      |> Enum.flat_map(fn name ->
+        case Map.get(lockfile, name) do
+          nil ->
+            []
+
+          entry ->
+            Map.keys(entry.dependencies) ++
+              Map.keys(Map.get(entry, :optional_dependencies, %{}))
+        end
+      end)
+      |> Enum.filter(fn name ->
+        case Map.get(lockfile, name) do
+          nil -> false
+          entry -> Map.get(entry, :optional, false)
+        end
+      end)
+      |> MapSet.new()
+
+    expanded = MapSet.union(skipped, descendants)
+
+    if MapSet.equal?(expanded, skipped) do
+      skipped
+    else
+      propagate_skipped_optional_descendants(expanded, lockfile)
+    end
   end
 
   defp platform_compatible?(name, version) do
@@ -375,10 +466,33 @@ defmodule NPM.Install.Linker do
   end
 
   defp optional_dependency?(name, lockfile) do
-    Enum.any?(lockfile, fn {_pkg, entry} ->
-      Map.has_key?(Map.get(entry, :optional_dependencies, %{}), name)
-    end)
+    case Map.get(lockfile, name) do
+      %{optional: true} ->
+        true
+
+      _entry ->
+        Enum.any?(lockfile, fn {_pkg, entry} ->
+          Map.has_key?(Map.get(entry, :optional_dependencies, %{}), name)
+        end)
+    end
   end
+
+  defp nested_under_skipped?(location, flat_skipped, skipped_locations) do
+    Enum.any?(flat_skipped, fn name ->
+      String.starts_with?(location, "node_modules/#{name}/node_modules/")
+    end) or
+      Enum.any?(skipped_locations, fn skipped_location ->
+        String.starts_with?(location, "#{skipped_location}/node_modules/")
+      end)
+  end
+
+  defp nested_target(nm_dir, "node_modules/" <> relative_location) do
+    Path.join(nm_dir, relative_location)
+  end
+
+  defp nested_target(nm_dir, location), do: Path.join(nm_dir, location)
+
+  defp location_depth(location), do: location |> String.split("/") |> length()
 
   defp install_single_nested(_pkg, nil, _parent, _nm_dir, _strategy), do: :ok
 

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -3,8 +3,8 @@ defmodule NPM.Install.Linker do
   Creates `node_modules` from the global cache.
 
   Supports multiple linking strategies:
-  - `:symlink` (default) — symlinks from `node_modules/pkg` to cache
-  - `:copy` — full file copy
+  - `:copy` (default) — full file copy
+  - `:symlink` — symlinks from `node_modules/pkg` to cache
 
   Uses a hoisted layout where packages are placed as high in the tree
   as possible, only nesting when version conflicts occur.
@@ -407,7 +407,7 @@ defmodule NPM.Install.Linker do
   end
 
   defp default_strategy do
-    :symlink
+    :copy
   end
 
   defp cache_concurrency do

--- a/apps/duskmoon_npm/lib/npm/install/script_install.ex
+++ b/apps/duskmoon_npm/lib/npm/install/script_install.ex
@@ -107,7 +107,10 @@ defmodule NPM.Install.ScriptInstall do
     case NPM.Lockfile.read(lockfile_path) do
       {:ok, lockfile} when lockfile != %{} ->
         Enum.all?(lockfile, fn {name, _} ->
-          File.exists?(Path.join([nm_dir, name, "package.json"]))
+          package_dir = Path.join(nm_dir, name)
+
+          match?({:ok, %File.Stat{type: :directory}}, File.lstat(package_dir)) and
+            File.exists?(Path.join(package_dir, "package.json"))
         end)
 
       _ ->

--- a/apps/duskmoon_npm/lib/npm/lockfile.ex
+++ b/apps/duskmoon_npm/lib/npm/lockfile.ex
@@ -49,6 +49,28 @@ defmodule NPM.Lockfile do
     read_file(path)
   end
 
+  @doc false
+  @spec read_nested(String.t()) :: {:ok, %{String.t() => entry()}} | {:error, term()}
+  def read_nested(path \\ @default_path) do
+    case read_json(path) do
+      {:ok, %{"packages" => packages} = data} when is_map(packages) ->
+        if package_lock?(data, packages) do
+          parse_nested_package_lock_packages(packages)
+        else
+          {:ok, %{}}
+        end
+
+      {:ok, _data} ->
+        {:ok, %{}}
+
+      {:error, :enoent} ->
+        {:ok, %{}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @doc """
   Migrates the legacy `npm.lock` schema to `package-lock.json` v3.
 
@@ -217,22 +239,88 @@ defmodule NPM.Lockfile do
     |> Enum.flat_map(fn {location, info} ->
       with false <- Map.get(info, "link") == true,
            {:ok, name} <- package_name_from_location(location) do
-        [
-          {name,
-           %{
-             version: Map.get(info, "version", ""),
-             integrity: Map.get(info, "integrity", ""),
-             tarball: Map.get(info, "resolved", ""),
-             dependencies: Map.get(info, "dependencies", %{}),
-             optional_dependencies: optional_dependencies(info),
-             has_install_script: has_install_script?(info)
-           }}
-        ]
+        [{name, package_lock_entry_from_info(info)}]
       else
         _ -> []
       end
     end)
     |> Map.new()
+  end
+
+  defp parse_nested_package_lock_packages(packages) do
+    packages
+    |> Enum.reduce_while({:ok, %{}}, fn {location, info}, {:ok, acc} ->
+      cond do
+        not nested_package_location?(location) or Map.get(info, "link") == true ->
+          {:cont, {:ok, acc}}
+
+        match?({:ok, _name}, nested_package_name(location)) ->
+          {:cont, {:ok, Map.put(acc, location, package_lock_entry_from_info(info))}}
+
+        true ->
+          {:halt, {:error, {:invalid_nested_package_location, location}}}
+      end
+    end)
+  end
+
+  defp nested_package_location?(location) do
+    String.starts_with?(location, "node_modules/") and
+      location
+      |> String.split("/")
+      |> Enum.count(&(&1 == "node_modules"))
+      |> Kernel.>(1)
+  end
+
+  @doc false
+  @spec nested_package_name(String.t()) :: {:ok, String.t()} | :error
+  def nested_package_name(location) do
+    location
+    |> String.split("/", trim: false)
+    |> parse_nested_location([])
+  end
+
+  defp parse_nested_location(["node_modules" | rest], parents) do
+    with {:ok, name, remaining} <- take_package_name(rest) do
+      case remaining do
+        [] when parents != [] -> {:ok, name}
+        ["node_modules" | _] -> parse_nested_location(remaining, [name | parents])
+        _ -> :error
+      end
+    end
+  end
+
+  defp parse_nested_location(_segments, _parents), do: :error
+
+  defp take_package_name(["@" <> scope = scoped, package | rest]) do
+    name = "#{scoped}/#{package}"
+
+    if scope != "" and NPM.Scope.valid_name?(name) do
+      {:ok, name, rest}
+    else
+      :error
+    end
+  end
+
+  defp take_package_name([package | rest]) do
+    if NPM.Scope.valid_name?(package) do
+      {:ok, package, rest}
+    else
+      :error
+    end
+  end
+
+  defp take_package_name(_segments), do: :error
+
+  defp package_lock_entry_from_info(info) do
+    %{
+      version: Map.get(info, "version", ""),
+      integrity: Map.get(info, "integrity", ""),
+      tarball: Map.get(info, "resolved", ""),
+      dependencies: Map.get(info, "dependencies", %{}),
+      optional_dependencies: optional_dependencies(info),
+      has_install_script: has_install_script?(info)
+    }
+    |> maybe_mark_optional(info)
   end
 
   defp parse_legacy_dependencies(deps) do
@@ -402,6 +490,7 @@ defmodule NPM.Lockfile do
       empty_to_nil(Map.get(entry, :optional_dependencies, %{}))
     )
     |> maybe_put("hasInstallScript", if(Map.get(entry, :has_install_script, false), do: true))
+    |> maybe_put("optional", if(Map.get(entry, :optional, false), do: true))
   end
 
   defp put_workspace_links(packages, manifests) do
@@ -503,6 +592,14 @@ defmodule NPM.Lockfile do
 
   defp has_install_script?(info) do
     Map.get(info, "hasInstallScript") || Map.get(info, "has_install_script", false)
+  end
+
+  defp maybe_mark_optional(entry, info) do
+    if Map.get(info, "optional", false) do
+      Map.put(entry, :optional, true)
+    else
+      entry
+    end
   end
 
   defp legacy_path?(path), do: Path.basename(path) == @legacy_path

--- a/apps/duskmoon_npm/lib/npm/tarball.ex
+++ b/apps/duskmoon_npm/lib/npm/tarball.ex
@@ -9,6 +9,7 @@ defmodule NPM.Tarball do
   @connect_timeout 30_000
   @pool_timeout 120_000
   @receive_timeout 120_000
+  @scoped_finch_options_req "0.7.0"
 
   @doc """
   Download a tarball, verify its integrity, and extract to a directory.
@@ -40,13 +41,7 @@ defmodule NPM.Tarball do
   end
 
   defp fetch(tarball_url) do
-    case Req.get(tarball_url,
-           decode_body: false,
-           connect_options: [timeout: @connect_timeout],
-           pool_timeout: @pool_timeout,
-           receive_timeout: @receive_timeout,
-           retry: false
-         ) do
+    case Req.get(tarball_url, request_options()) do
       {:ok, %{status: status}} = response when status in 200..499 ->
         response
 
@@ -55,6 +50,33 @@ defmodule NPM.Tarball do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec __request_options__(String.t()) :: keyword()
+  def __request_options__(req_version) do
+    pool_timeout_options =
+      if Version.compare(req_version, @scoped_finch_options_req) == :lt do
+        [pool_timeout: @pool_timeout]
+      else
+        [finch: [pool_timeout: @pool_timeout]]
+      end
+
+    [
+      decode_body: false,
+      connect_options: [timeout: @connect_timeout],
+      receive_timeout: @receive_timeout,
+      retry: false
+    ] ++ pool_timeout_options
+  end
+
+  defp request_options, do: __request_options__(req_version())
+
+  defp req_version do
+    case Application.spec(:req, :vsn) do
+      nil -> "0.0.0"
+      version -> to_string(version)
     end
   end
 

--- a/apps/duskmoon_npm/mix.exs
+++ b/apps/duskmoon_npm/mix.exs
@@ -28,7 +28,7 @@ defmodule DuskmoonNpm.MixProject do
   end
 
   def application do
-    [extra_applications: [:crypto]]
+    [extra_applications: [:crypto, :ssl]]
   end
 
   defp aliases do

--- a/apps/duskmoon_npm/test/npm/cache_test.exs
+++ b/apps/duskmoon_npm/test/npm/cache_test.exs
@@ -105,6 +105,13 @@ defmodule NPM.CacheTest do
     assert Cache.cached?("partial-package", "1.0.0")
   end
 
+  test "uses each package version as a lock resource and the process as requester" do
+    requester = make_ref()
+
+    assert Cache.__lock_id__("package", "1.2.3", requester) ==
+             {{Cache, "package", "1.2.3"}, requester}
+  end
+
   defp restore_env(key, nil), do: System.delete_env(key)
   defp restore_env(key, value), do: System.put_env(key, value)
 

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -2,6 +2,7 @@ defmodule NPM.Install.LinkerTest do
   use ExUnit.Case, async: false
 
   alias NPM.Install.Linker
+  alias NPM.Resolution.PackageResolver
 
   setup do
     old_cache_dir = Application.get_env(:duskmoon_npm, :cache_dir)
@@ -45,12 +46,53 @@ defmodule NPM.Install.LinkerTest do
              )
   end
 
-  test "links cached packages with symlinks by default", %{tmp_dir: tmp_dir} do
-    cache_path = write_cached_package!("cached-pkg", "1.0.0")
+  test "copies cached packages so sibling dependencies resolve from node_modules", %{
+    tmp_dir: tmp_dir
+  } do
+    importer = "importer-pkg"
+    sibling = "sibling-pkg"
+    importer_cache_path = write_cached_package!(importer, "1.0.0")
+    sibling_cache_path = write_cached_package!(sibling, "2.0.0")
     node_modules = Path.join(tmp_dir, "node_modules")
 
-    assert :ok = Linker.link(%{"cached-pkg" => lock_entry("1.0.0")}, node_modules)
-    assert {:ok, ^cache_path} = File.read_link(Path.join(node_modules, "cached-pkg"))
+    File.write!(
+      Path.join(importer_cache_path, "index.js"),
+      ~s[module.exports = require("#{sibling}");]
+    )
+
+    File.write!(Path.join(sibling_cache_path, "index.js"), ~s[module.exports = "resolved";])
+
+    lockfile = %{
+      importer => %{
+        lock_entry(importer, "1.0.0")
+        | dependencies: %{sibling => "2.0.0"}
+      },
+      sibling => lock_entry(sibling, "2.0.0")
+    }
+
+    assert :ok = Linker.link(lockfile, node_modules)
+
+    installed_importer = Path.join(node_modules, importer)
+    installed_sibling = Path.join(node_modules, sibling)
+
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_importer)
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_sibling)
+    assert File.read!(Path.join(installed_importer, "index.js")) =~ sibling
+
+    assert File.read!(Path.join(installed_importer, "package.json")) ==
+             File.read!(Path.join(importer_cache_path, "package.json"))
+
+    assert File.read!(Path.join(installed_sibling, "package.json")) ==
+             File.read!(Path.join(sibling_cache_path, "package.json"))
+
+    canonical_importer =
+      case File.read_link(installed_importer) do
+        {:ok, target} -> Path.expand(target, Path.dirname(installed_importer))
+        {:error, :einval} -> installed_importer
+      end
+
+    assert {:ok, sibling_entry} = PackageResolver.resolve(sibling, canonical_importer)
+    assert sibling_entry == Path.join(installed_sibling, "index.js")
   end
 
   test "returns cache population errors directly", %{tmp_dir: tmp_dir} do
@@ -83,11 +125,11 @@ defmodule NPM.Install.LinkerTest do
     cache_path
   end
 
-  defp lock_entry(version) do
+  defp lock_entry(package, version) do
     %{
       version: version,
       integrity: "",
-      tarball: "https://registry.npmjs.org/cached-pkg/-/cached-pkg-#{version}.tgz",
+      tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
       dependencies: %{},
       optional_dependencies: %{},
       has_install_script: false

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -111,6 +111,73 @@ defmodule NPM.Install.LinkerTest do
              Linker.link(%{"blocked-pkg" => entry}, node_modules)
   end
 
+  test "skips optional descendants of a platform-incompatible package", %{
+    tmp_dir: tmp_dir
+  } do
+    root = "root-pkg"
+    optional = "other-platform-pkg"
+    descendant = "optional-descendant-pkg"
+    shared = "shared-required-pkg"
+    node_modules = Path.join(tmp_dir, "node_modules")
+
+    write_cached_package!(root, "1.0.0")
+    write_cached_package!(shared, "1.0.0")
+    put_incompatible_packument!(optional, "1.0.0")
+
+    lockfile = %{
+      root =>
+        lock_entry("1.0.0",
+          tarball: "https://registry.npmjs.org/root-pkg/-/root-pkg-1.0.0.tgz",
+          dependencies: %{shared => "1.0.0"},
+          optional_dependencies: %{optional => "1.0.0"}
+        ),
+      optional =>
+        lock_entry("1.0.0",
+          tarball: "https://blocked.example/other-platform-pkg-1.0.0.tgz",
+          dependencies: %{descendant => "1.0.0", shared => "1.0.0"},
+          optional: true
+        ),
+      descendant =>
+        lock_entry("1.0.0",
+          tarball: "https://blocked.example/optional-descendant-pkg-1.0.0.tgz",
+          optional: true
+        ),
+      shared =>
+        lock_entry("1.0.0",
+          tarball:
+            "https://registry.npmjs.org/shared-required-pkg/-/shared-required-pkg-1.0.0.tgz"
+        )
+    }
+
+    assert :ok = Linker.link(lockfile, node_modules)
+    assert File.exists?(Path.join([node_modules, root, "package.json"]))
+    assert File.exists?(Path.join([node_modules, shared, "package.json"]))
+    refute File.exists?(Path.join([node_modules, optional, "package.json"]))
+    refute File.exists?(Path.join([node_modules, descendant, "package.json"]))
+  end
+
+  test "rejects unsafe nested lockfile locations before filesystem access", %{
+    tmp_dir: tmp_dir
+  } do
+    node_modules = Path.join(tmp_dir, "node_modules")
+    entry = lock_entry("1.0.0")
+
+    unsafe_locations = [
+      "node_modules/parent/node_modules/..",
+      "node_modules/parent/node_modules/",
+      "node_modules/parent/extra/node_modules/child",
+      "node_modules/../../escaped/node_modules/child",
+      "/node_modules/parent/node_modules/child"
+    ]
+
+    Enum.each(unsafe_locations, fn location ->
+      assert {:error, {:invalid_nested_package_location, ^location}} =
+               Linker.link_nested_lockfile(%{location => entry}, node_modules)
+    end)
+
+    refute File.exists?(Path.join(tmp_dir, "escaped"))
+  end
+
   defp write_cached_package!(name, version) do
     cache_path = NPM.Cache.package_dir(name, version)
     File.mkdir_p!(cache_path)
@@ -125,16 +192,50 @@ defmodule NPM.Install.LinkerTest do
     cache_path
   end
 
-  defp lock_entry(package, version) do
+  defp lock_entry(version), do: lock_entry(version, [])
+
+  defp lock_entry(package, version) when is_binary(version) do
+    lock_entry(version,
+      tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz"
+    )
+  end
+
+  defp lock_entry(version, opts) when is_list(opts) do
     %{
       version: version,
       integrity: "",
-      tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
-      dependencies: %{},
-      optional_dependencies: %{},
+      tarball:
+        Keyword.get(
+          opts,
+          :tarball,
+          "https://registry.npmjs.org/cached-pkg/-/cached-pkg-#{version}.tgz"
+        ),
+      dependencies: Keyword.get(opts, :dependencies, %{}),
+      optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
       has_install_script: false
     }
+    |> maybe_put_optional(Keyword.get(opts, :optional, false))
   end
+
+  defp put_incompatible_packument!(package, version) do
+    other_os = if NPM.Platform.current_os() == "darwin", do: "linux", else: "darwin"
+
+    NPM.PackumentCache.put(package, %{
+      name: package,
+      versions: %{
+        version => %{
+          os: [other_os],
+          cpu: [],
+          dependencies: %{},
+          optional_dependencies: %{},
+          dist: %{tarball: "", integrity: ""}
+        }
+      }
+    })
+  end
+
+  defp maybe_put_optional(entry, true), do: Map.put(entry, :optional, true)
+  defp maybe_put_optional(entry, false), do: entry
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)
   defp restore_app_env(key, value), do: Application.put_env(:duskmoon_npm, key, value)

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -460,6 +460,29 @@ defmodule NPM.InstallTest do
     assert output =~ "package-lock.json not found. Run `mix npm.install` first."
   end
 
+  test "npm.ci starts SSL before installing", %{project_dir: project_dir} do
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{"name" => "ssl_startup_project"})
+    )
+
+    {:ok, _started} = Application.ensure_all_started(:ssl)
+    on_exit(fn -> Application.ensure_all_started(:ssl) end)
+    assert :ok = Application.stop(:ssl)
+    refute List.keymember?(Application.started_applications(), :ssl, 0)
+
+    Mix.Task.reenable("npm.ci")
+
+    capture_io(fn ->
+      assert :ok = Mix.Tasks.Npm.Ci.run([])
+    end)
+
+    assert {:ssl, _description, _version} =
+             List.keyfind(Application.started_applications(), :ssl, 0)
+
+    assert :ssl in Application.spec(:duskmoon_npm, :applications)
+  end
+
   defp write_cached_package!(name, version) do
     cache_path = NPM.Cache.package_dir(name, version)
     File.mkdir_p!(cache_path)

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -53,7 +53,39 @@ defmodule NPM.InstallTest do
     assert output =~ "Installing from current package-lock.json."
     assert output =~ "Installed 1 package"
     assert output =~ "* #{package} #{version} (npm registry)"
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+  end
+
+  test "replaces cache symlinks left by earlier installs", %{project_dir: project_dir} do
+    package = "legacy-symlink-package"
+    version = "1.0.0"
+    cache_path = write_cached_package!(package, version)
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "legacy_symlink_project",
+        "dependencies" => %{package => version}
+      })
+    )
+
+    assert :ok = NPM.Lockfile.write(%{package => lock_entry(package, version)})
+
+    installed_path = Path.join([project_dir, "node_modules", package])
+    File.mkdir_p!(Path.dirname(installed_path))
+    File.ln_s!(cache_path, installed_path)
+
+    output =
+      capture_io(fn ->
+        assert :ok = NPM.install()
+      end)
+
+    assert output =~ "Installing from current package-lock.json."
+    assert_copied_package(cache_path, installed_path)
   end
 
   test "re-resolves a lockfile with missing transitive package records", %{
@@ -93,7 +125,7 @@ defmodule NPM.InstallTest do
       end)
 
     refute output =~ "Already up to date."
-    assert {:ok, ^dependency_cache_path} = File.read_link(Path.join(node_modules, dependency))
+    assert_copied_package(dependency_cache_path, Path.join(node_modules, dependency))
 
     assert {:ok, lockfile} = NPM.Lockfile.read()
     assert Map.has_key?(lockfile, dependency)
@@ -127,7 +159,7 @@ defmodule NPM.InstallTest do
 
     node_modules = Path.join(project_dir, "node_modules")
     File.mkdir_p!(node_modules)
-    File.ln_s!(cache_path, Path.join(node_modules, package))
+    File.cp_r!(cache_path, Path.join(node_modules, package))
 
     output =
       capture_io(fn ->
@@ -165,7 +197,12 @@ defmodule NPM.InstallTest do
       end)
 
     assert output =~ "Installing from current package-lock.json."
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+
     assert {:ok, ^app_dir} = File.read_link(Path.join([project_dir, "node_modules", "web"]))
     assert File.exists?(Path.join(project_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "package-lock.json"))
@@ -207,7 +244,7 @@ defmodule NPM.InstallTest do
       end)
 
     refute output =~ "Already up to date."
-    assert {:ok, ^new_cache_path} = File.read_link(Path.join(node_modules, package))
+    assert_copied_package(new_cache_path, Path.join(node_modules, package))
     assert {:ok, ^app_dir} = File.read_link(Path.join([node_modules, "web"]))
 
     assert {:ok, lockfile} = NPM.Lockfile.read(Path.join(project_dir, "package-lock.json"))
@@ -242,7 +279,12 @@ defmodule NPM.InstallTest do
 
     assert %{"dependencies" => %{^package => ^version}} = read_package!(app_dir)
     refute Map.has_key?(read_package!(project_dir), "dependencies")
-    assert {:ok, ^cache_path} = File.read_link(Path.join([project_dir, "node_modules", package]))
+
+    assert_copied_package(
+      cache_path,
+      Path.join([project_dir, "node_modules", package])
+    )
+
     assert File.exists?(Path.join(project_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "package-lock.json"))
     refute File.exists?(Path.join(app_dir, "node_modules"))
@@ -345,6 +387,13 @@ defmodule NPM.InstallTest do
     |> Path.join("package.json")
     |> NPM.JSON.read_file()
     |> then(fn {:ok, data} -> data end)
+  end
+
+  defp assert_copied_package(cache_path, installed_path) do
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_path)
+
+    assert File.read!(Path.join(installed_path, "package.json")) ==
+             File.read!(Path.join(cache_path, "package.json"))
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -229,9 +229,94 @@ defmodule NPM.InstallTest do
                parser_dependency
              ])
 
+    assert {:ok, %{"packages" => packages}} = NPM.JSON.read_file("package-lock.json")
+
+    Enum.each([other_mermaid, parser, parser_dependency], fn name ->
+      assert packages["node_modules/#{name}"]["optional"] == true
+    end)
+
     capture_io(fn ->
       assert :ok = NPM.install(frozen: true)
     end)
+  end
+
+  test "nests marked 16 for optional mermaid beside flat marked 18", %{
+    project_dir: project_dir
+  } do
+    markdown = "@duskmoon-dev/el-markdown"
+    markdown_input = "@duskmoon-dev/el-markdown-input"
+    mermaid = "mermaid"
+    marked = "marked"
+
+    platform_mermaid =
+      "mermaid-#{NPM.Platform.current_os()}-#{NPM.Platform.current_cpu()}"
+
+    Enum.each(
+      [
+        {markdown, "1.5.3"},
+        {markdown_input, "1.5.3"},
+        {platform_mermaid, "1.0.0"},
+        {mermaid, "11.15.0"},
+        {marked, "16.3.0"},
+        {marked, "18.0.4"}
+      ],
+      fn {name, version} -> write_cached_package!(name, version) end
+    )
+
+    put_packument!(markdown, "1.5.3", dependencies: %{marked => "18.0.4"})
+
+    put_packument!(markdown_input, "1.5.3",
+      optional_dependencies: %{
+        mermaid => "11.15.0",
+        platform_mermaid => "1.0.0"
+      }
+    )
+
+    put_packument!(platform_mermaid, "1.0.0")
+    put_packument!(mermaid, "11.15.0", dependencies: %{marked => "^16.3.0"})
+
+    put_packument_versions!(marked, [
+      {"16.3.0", []},
+      {"18.0.4", []}
+    ])
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "marked_version_conflict_project",
+        "dependencies" => %{
+          markdown => "1.5.3",
+          markdown_input => "1.5.3"
+        }
+      })
+    )
+
+    capture_io(fn ->
+      assert :ok = NPM.install()
+    end)
+
+    assert {:ok, %{"packages" => packages}} = NPM.JSON.read_file("package-lock.json")
+    assert packages["node_modules/marked"]["version"] == "18.0.4"
+    assert packages["node_modules/mermaid"]["version"] == "11.15.0"
+    assert packages["node_modules/mermaid"]["optional"] == true
+
+    nested_marked = "node_modules/mermaid/node_modules/marked"
+    assert packages[nested_marked]["version"] == "16.3.0"
+    assert packages[nested_marked]["optional"] == true
+    assert installed_version!(nested_marked) == "16.3.0"
+
+    File.rm_rf!("node_modules")
+
+    mermaid
+    |> NPM.Cache.package_dir("11.15.0")
+    |> Path.join("node_modules")
+    |> File.rm_rf!()
+
+    capture_io(fn ->
+      assert :ok = NPM.install(frozen: true)
+    end)
+
+    assert installed_version!(nested_marked) == "16.3.0"
   end
 
   test "installs from workspace package using the workspace root", %{project_dir: project_dir} do
@@ -401,26 +486,32 @@ defmodule NPM.InstallTest do
   end
 
   defp put_packument!(package, version, opts \\ []) do
+    put_packument_versions!(package, [{version, opts}])
+  end
+
+  defp put_packument_versions!(package, versions) do
     NPM.PackumentCache.put(package, %{
       name: package,
-      versions: %{
-        version => %{
-          os: [],
-          cpu: [],
-          dependencies: Keyword.get(opts, :dependencies, %{}),
-          optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
-          peer_dependencies: %{},
-          peer_dependencies_meta: %{},
-          dist: %{
-            tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
-            integrity: ""
-          },
-          has_install_script: false,
-          deprecated: nil,
-          created_at: nil,
-          published_at: nil
-        }
-      }
+      versions:
+        Map.new(versions, fn {version, opts} ->
+          {version,
+           %{
+             os: [],
+             cpu: [],
+             dependencies: Keyword.get(opts, :dependencies, %{}),
+             optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
+             peer_dependencies: %{},
+             peer_dependencies_meta: %{},
+             dist: %{
+               tarball: "https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz",
+               integrity: ""
+             },
+             has_install_script: false,
+             deprecated: nil,
+             created_at: nil,
+             published_at: nil
+           }}
+        end)
     })
   end
 
@@ -458,6 +549,13 @@ defmodule NPM.InstallTest do
 
     assert File.read!(Path.join(installed_path, "package.json")) ==
              File.read!(Path.join(cache_path, "package.json"))
+  end
+
+  defp installed_version!(package_dir) do
+    package_dir
+    |> Path.join("package.json")
+    |> NPM.JSON.read_file()
+    |> then(fn {:ok, %{"version" => version}} -> version end)
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -170,6 +170,70 @@ defmodule NPM.InstallTest do
     refute File.exists?(Path.join([node_modules, optional_package, "package.json"]))
   end
 
+  test "locks required dependencies of optional packages excluded from resolution", %{
+    project_dir: project_dir
+  } do
+    package = "@duskmoon-dev/el-markdown-input"
+    version = "1.5.5"
+    current_mermaid = "mermaid-#{NPM.Platform.current_os()}-#{NPM.Platform.current_cpu()}"
+    other_mermaid = "mermaid-darwin-arm64"
+    parser = "@mermaid-js/parser"
+    parser_dependency = "langium"
+
+    other_mermaid =
+      if other_mermaid == current_mermaid, do: "mermaid-linux-x64", else: other_mermaid
+
+    Enum.each(
+      [
+        {package, version},
+        {current_mermaid, "11.15.0"},
+        {other_mermaid, "11.15.0"},
+        {parser, "1.1.1"},
+        {parser_dependency, "3.3.1"}
+      ],
+      fn {name, package_version} -> write_cached_package!(name, package_version) end
+    )
+
+    put_packument!(package, version,
+      optional_dependencies: %{
+        current_mermaid => "11.15.0",
+        other_mermaid => "11.15.0"
+      }
+    )
+
+    put_packument!(current_mermaid, "11.15.0")
+    put_packument!(other_mermaid, "11.15.0", dependencies: %{parser => "1.1.1"})
+    put_packument!(parser, "1.1.1", dependencies: %{parser_dependency => "3.3.1"})
+    put_packument!(parser_dependency, "3.3.1")
+
+    File.write!(
+      Path.join(project_dir, "package.json"),
+      NPM.JSON.encode_pretty(%{
+        "name" => "mermaid_optional_dependency_project",
+        "dependencies" => %{package => version}
+      })
+    )
+
+    capture_io(fn ->
+      assert :ok = NPM.install()
+    end)
+
+    assert {:ok, package_names} = NPM.Lockfile.all_package_names()
+
+    assert MapSet.new(package_names) ==
+             MapSet.new([
+               package,
+               current_mermaid,
+               other_mermaid,
+               parser,
+               parser_dependency
+             ])
+
+    capture_io(fn ->
+      assert :ok = NPM.install(frozen: true)
+    end)
+  end
+
   test "installs from workspace package using the workspace root", %{project_dir: project_dir} do
     package = "workspace-root-package"
     version = "1.0.0"

--- a/apps/duskmoon_npm/test/npm/lockfile_test.exs
+++ b/apps/duskmoon_npm/test/npm/lockfile_test.exs
@@ -116,19 +116,44 @@ defmodule NPM.LockfileTest do
              NPM.Lockfile.write(
                %{"parent" => lock_entry("1.0.0")},
                nested: %{
-                 "node_modules/parent/node_modules/nested" => lock_entry("2.0.0")
+                 "node_modules/parent/node_modules/nested" =>
+                   Map.put(lock_entry("2.0.0"), :optional, true)
                }
              )
 
     assert %{
              "packages" => %{
                "node_modules/parent" => %{"version" => "1.0.0"},
-               "node_modules/parent/node_modules/nested" => %{"version" => "2.0.0"}
+               "node_modules/parent/node_modules/nested" => %{
+                 "version" => "2.0.0",
+                 "optional" => true
+               }
              }
            } = read_json!("package-lock.json")
 
     assert {:ok, ["nested", "parent"]} = NPM.Lockfile.all_package_names()
     assert {:ok, %{"parent" => %{version: "1.0.0"}}} = NPM.Lockfile.read()
+
+    assert {:ok,
+            %{
+              "node_modules/parent/node_modules/nested" => %{
+                version: "2.0.0",
+                optional: true
+              }
+            }} = NPM.Lockfile.read_nested()
+  end
+
+  test "rejects unsafe nested package-lock locations while reading" do
+    location = "node_modules/parent/node_modules/.."
+
+    assert :ok =
+             NPM.Lockfile.write(
+               %{"parent" => lock_entry("1.0.0")},
+               nested: %{location => lock_entry("2.0.0")}
+             )
+
+    assert {:error, {:invalid_nested_package_location, ^location}} =
+             NPM.Lockfile.read_nested()
   end
 
   test "package-lock analyzer skips workspace links and nested packages" do

--- a/apps/duskmoon_npm/test/npm/tarball_test.exs
+++ b/apps/duskmoon_npm/test/npm/tarball_test.exs
@@ -1,0 +1,17 @@
+defmodule NPM.TarballTest do
+  use ExUnit.Case, async: true
+
+  test "scopes the pool timeout under Finch for Req 0.7 and later" do
+    options = NPM.Tarball.__request_options__("0.7.0")
+
+    assert options[:finch][:pool_timeout] == 120_000
+    refute Keyword.has_key?(options, :pool_timeout)
+  end
+
+  test "keeps the top-level pool timeout for older Req versions" do
+    options = NPM.Tarball.__request_options__("0.6.3")
+
+    assert options[:pool_timeout] == 120_000
+    refute Keyword.has_key?(options, :finch)
+  end
+end

--- a/apps/duskmoon_storybook/mix.exs
+++ b/apps/duskmoon_storybook/mix.exs
@@ -48,7 +48,7 @@ defmodule DuskmoonStorybook.MixProject do
       {:phoenix_pubsub, "~> 2.2"},
       {:lazy_html, "~> 0.1.0"},
       {:duskmoon_bundler_runtime, in_umbrella: true},
-      {:duskmoon_bundler, in_umbrella: true, runtime: Mix.env() == :dev},
+      {:duskmoon_bundler, in_umbrella: true, runtime: Mix.env() in [:dev, :test]},
       {:telemetry_metrics, "~> 1.0"},
       {:telemetry_poller, "~> 1.3"},
       {:gettext, "~> 1.0"},

--- a/skills/duskmoon_bundler/SKILL.md
+++ b/skills/duskmoon_bundler/SKILL.md
@@ -45,7 +45,7 @@ running Igniter. Add both dependencies:
 def deps do
   [
     {:duskmoon_bundler_runtime, "~> 9.7"},
-    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() == :dev}
+    {:duskmoon_bundler, "~> 9.7", runtime: Mix.env() in [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
## Summary
- copy registry packages into node_modules so sibling dependency resolution works (#102)
- preserve complete optional and nested dependency graphs in frozen installs (#103)
- start SSL before npm CI fetches (#106)
- start the bundler runtime for code-reloading tests and update generated configuration (#107)
- select Req-compatible pool timeout options for both Req 0.6 and 0.7+ (#108)
- serialize shared npm cache and JS runtime installs to prevent parallel workflow corruption

## Validation
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- Duskmoon NPM: 52 tests, 0 failures
- Duskmoon Bundler: 2 doctests, 441 tests, 0 failures

Fixes #102
Fixes #103
Fixes #106
Fixes #107
Fixes #108