### PR TITLE
fix: make tarball options compatible with Req 0.7

### DIFF
--- a/apps/duskmoon_npm/lib/npm/tarball.ex
+++ b/apps/duskmoon_npm/lib/npm/tarball.ex
@@ -56,19 +56,26 @@ defmodule NPM.Tarball do
   @doc false
   @spec __request_options__(String.t()) :: keyword()
   def __request_options__(req_version) do
-    pool_timeout_options =
+    adapter_options =
       if Version.compare(req_version, @scoped_finch_options_req) == :lt do
-        [pool_timeout: @pool_timeout]
+        [
+          connect_options: [timeout: @connect_timeout],
+          pool_timeout: @pool_timeout
+        ]
       else
-        [finch: [pool_timeout: @pool_timeout]]
+        [
+          finch: [
+            conn_opts: [transport_opts: [timeout: @connect_timeout]],
+            pool_timeout: @pool_timeout
+          ]
+        ]
       end
 
     [
       decode_body: false,
-      connect_options: [timeout: @connect_timeout],
       receive_timeout: @receive_timeout,
       retry: false
-    ] ++ pool_timeout_options
+    ] ++ adapter_options
   end
 
   defp request_options, do: __request_options__(req_version())

--- a/apps/duskmoon_npm/test/npm/tarball_test.exs
+++ b/apps/duskmoon_npm/test/npm/tarball_test.exs
@@ -2,15 +2,18 @@ defmodule NPM.TarballTest do
   use ExUnit.Case, async: true
 
   test "scopes the pool timeout under Finch for Req 0.7 and later" do
-    options = NPM.Tarball.__request_options__("0.7.0")
+    options = NPM.Tarball.__request_options__("0.7.1")
 
     assert options[:finch][:pool_timeout] == 120_000
+    assert options[:finch][:conn_opts][:transport_opts][:timeout] == 30_000
     refute Keyword.has_key?(options, :pool_timeout)
+    refute Keyword.has_key?(options, :connect_options)
   end
 
-  test "keeps the top-level pool timeout for older Req versions" do
+  test "keeps the top-level connection and pool timeouts for older Req versions" do
     options = NPM.Tarball.__request_options__("0.6.3")
 
+    assert options[:connect_options][:timeout] == 30_000
     assert options[:pool_timeout] == 120_000
     refute Keyword.has_key?(options, :finch)
   end


### PR DESCRIPTION
## Summary
- move the Req 0.7 connect timeout into Finch pool connection options
- avoid the forbidden `:finch` and top-level `:connect_options` combination
- retain the Req 0.6 option shape and cover both versions with tests

## Validation
- `mix test apps/duskmoon_npm/test` — 52 tests, 0 failures
- real Req 0.7.1 adapter probe accepted the options
- `mix format --check-formatted apps/duskmoon_npm/lib/npm/tarball.ex apps/duskmoon_npm/test/npm/tarball_test.exs`

Fixes #117