### PR TITLE
fix: rewrite normalized cross-chunk imports

### DIFF
--- a/apps/duskmoon_bundler/CHANGELOG.md
+++ b/apps/duskmoon_bundler/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `json_codec` as a runtime dependency.
 
 ### Fixed
+- ESM code-split builds now rewrite Rolldown-normalized cross-chunk npm imports to emitted chunk URLs instead of leaving package specifiers in the output.
 - Generated installs now start `:duskmoon_bundler` in test, ensuring endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 - HMR websocket no longer drops idle connections after 60 seconds. The browser client now sends a periodic `{"type":"ping"}` heartbeat, and the server replies with `{"type":"pong"}`, preventing Bandit's websocket `read_timeout` from closing an otherwise idle socket. The client also tracks pongs and force-reconnects if the link goes half-open. This eliminates the spurious `[DuskmoonBundler] Disconnected. Reconnecting...` console noise observed on long-lived demo/dev pages with no file changes.
 

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
@@ -361,14 +361,30 @@ defmodule DuskmoonBundler.Builder.Output do
   end
 
   defp chunk_import_map(chunk, graph, module_labels, dep_map) do
+    chunk_entry_label = chunk.modules |> List.first() |> then(&module_labels[&1])
+
     chunk.modules
     |> Enum.flat_map(fn importer ->
-      module_chunk_imports(importer, chunk.id, graph, module_labels, dep_map)
+      module_chunk_imports(
+        importer,
+        chunk_entry_label,
+        chunk.id,
+        graph,
+        module_labels,
+        dep_map
+      )
     end)
     |> Map.new()
   end
 
-  defp module_chunk_imports(importer, current_chunk_id, graph, module_labels, dep_map) do
+  defp module_chunk_imports(
+         importer,
+         chunk_entry_label,
+         current_chunk_id,
+         graph,
+         module_labels,
+         dep_map
+       ) do
     importer_label = module_labels[importer]
     deps = Map.get(dep_map, importer, %DuskmoonBundler.Builder.Dependencies{})
 
@@ -377,11 +393,21 @@ defmodule DuskmoonBundler.Builder.Output do
       with chunk_id when is_binary(chunk_id) <- Map.get(graph.module_to_chunk, dep),
            false <- chunk_id == current_chunk_id,
            dep_label when is_binary(dep_label) <- module_labels[dep] do
-        [{"./" <> relative_label(importer_label, dep_label), chunk_id}]
+        [
+          {"./" <> relative_label(importer_label, dep_label), chunk_id},
+          {module_specifier(chunk_entry_label, dep_label), chunk_id}
+        ]
       else
         _ -> []
       end
     end)
+  end
+
+  defp module_specifier(from_label, to_label) do
+    case relative_label(from_label, to_label) do
+      "." <> _ = relative -> relative
+      relative -> "./" <> relative
+    end
   end
 
   defp relative_label(from_label, to_label) do

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -1183,6 +1183,75 @@ defmodule DuskmoonBundler.BuilderTest do
       assert js =~ "fake-widget"
     end
 
+    test "minified ESM rewrites normalized cross-chunk npm imports" do
+      el_base_dir =
+        Path.join(@fixture_dir, "node_modules/@duskmoon-dev/el-base/dist/esm")
+
+      elements_dir =
+        Path.join(@fixture_dir, "node_modules/@duskmoon-dev/elements/dist/esm")
+
+      File.mkdir_p!(el_base_dir)
+      File.mkdir_p!(elements_dir)
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/@duskmoon-dev/el-base/package.json"),
+        ~s({"name":"@duskmoon-dev/el-base","type":"module","exports":{"import":"./dist/esm/index.js"}})
+      )
+
+      File.write!(
+        Path.join(el_base_dir, "index.js"),
+        "export const register = () => { globalThis.__elBase = 'bundled-el-base' };\n"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/@duskmoon-dev/elements/package.json"),
+        ~s({"name":"@duskmoon-dev/elements","type":"module","exports":{"import":"./dist/esm/index.js"}})
+      )
+
+      File.write!(
+        Path.join(elements_dir, "index.js"),
+        """
+        import { register } from '@duskmoon-dev/el-base'
+        export const registerAll = () => {
+          register()
+          import('./lazy.js')
+        }
+        """
+      )
+
+      File.write!(
+        Path.join(elements_dir, "lazy.js"),
+        """
+        import { register } from '@duskmoon-dev/el-base'
+        register()
+        """
+      )
+
+      File.write!(Path.join(@fixture_dir, "src/minified_esm_app.ts"), """
+      import { registerAll } from '@duskmoon-dev/elements'
+      registerAll()
+      """)
+
+      {:ok, result} =
+        DuskmoonBundler.Builder.build(
+          entry: Path.join(@fixture_dir, "src/minified_esm_app.ts"),
+          outdir: @outdir,
+          format: :esm,
+          hash: false,
+          minify: true,
+          sourcemap: false,
+          node_modules: Path.join(@fixture_dir, "node_modules")
+        )
+
+      js =
+        result.chunks
+        |> Enum.map_join("\n", &File.read!(&1.path))
+
+      assert js =~ "bundled-el-base"
+      refute js =~ "@duskmoon-dev/el-base"
+      refute js =~ "@duskmoon-dev/elements"
+    end
+
     test "plugin content_type overrides file extension dispatch" do
       File.write!(Path.join(@fixture_dir, "src/data.custom"), """
       export const value = 42;


### PR DESCRIPTION
## Summary
- track both importer-relative and chunk-entry-relative spellings for cross-chunk modules
- rewrite Rolldown-normalized npm paths to emitted chunk URLs in minified ESM builds
- add a code-splitting regression fixture matching the DuskMoon elements package layout

## Validation
- `MIX_ENV=test mix test apps/duskmoon_bundler/test` (442 tests, 2 doctests, 0 failures)
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- full `@duskmoon-dev/elements` + `@duskmoon-dev/art-elements` graph diagnostic

Fixes #118