### PR TITLE
fix: make npm.verify CI-safe

### DIFF
--- a/apps/duskmoon_npm/lib/mix/tasks/npm.verify.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.verify.ex
@@ -24,23 +24,32 @@ defmodule Mix.Tasks.Npm.Verify do
         case NPM.Workspace.read_all() do
           {:ok, project} ->
             expected = expected_packages(lockfile, project.local_links)
-            expected |> NPM.NodeModules.diff() |> report_diff(map_size(expected))
+            skipped = NPM.Install.Linker.skipped_packages(lockfile)
+
+            expected
+            |> NPM.NodeModules.diff()
+            |> ignore_missing(skipped)
+            |> report_diff(map_size(expected) - MapSet.size(skipped))
 
           {:error, reason} ->
-            Mix.shell().error("Failed: #{inspect(reason)}")
+            Mix.raise("npm.verify failed: #{inspect(reason)}")
         end
 
       {:error, reason} ->
-        Mix.shell().error("Failed: #{inspect(reason)}")
+        Mix.raise("npm.verify failed: #{inspect(reason)}")
     end
   end
 
   def run(_) do
-    Mix.shell().error("Usage: mix npm.verify")
+    Mix.raise("Usage: mix npm.verify")
   end
 
   defp expected_packages(lockfile, local_links) do
     Map.merge(lockfile, Map.new(local_links, fn {name, _path} -> {name, %{}} end))
+  end
+
+  defp ignore_missing({missing, extra}, skipped) do
+    {Enum.reject(missing, &MapSet.member?(skipped, &1)), extra}
   end
 
   defp report_diff({[], []}, count) do
@@ -49,6 +58,7 @@ defmodule Mix.Tasks.Npm.Verify do
 
   defp report_diff({missing, extra}, _count) do
     Enum.each(missing, &Mix.shell().error("  missing: #{&1}"))
-    Enum.each(extra, &Mix.shell().info("  extra: #{&1}"))
+    Enum.each(extra, &Mix.shell().error("  extra: #{&1}"))
+    Mix.raise("node_modules does not match lockfile")
   end
 end

--- a/apps/duskmoon_npm/test/mix/tasks/npm_verify_test.exs
+++ b/apps/duskmoon_npm/test/mix/tasks/npm_verify_test.exs
@@ -1,0 +1,139 @@
+defmodule Mix.Tasks.Npm.VerifyTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  setup do
+    old_cwd = File.cwd!()
+
+    tmp_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "npm_verify_test_#{System.unique_integer([:positive])}"
+      ])
+
+    File.mkdir_p!(tmp_dir)
+    File.cd!(tmp_dir)
+    File.write!("package.json", NPM.JSON.encode_pretty(%{"name" => "verify-test"}))
+
+    on_exit(fn ->
+      File.cd!(old_cwd)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    :ok
+  end
+
+  test "ignores an absent platform-incompatible optional package" do
+    optional = "verify-optional-#{System.unique_integer([:positive])}"
+    put_incompatible_packument!(optional, "1.0.0")
+
+    write_lockfile!(%{
+      "required" => lock_entry(optional_dependencies: %{optional => "1.0.0"}),
+      optional => lock_entry()
+    })
+
+    File.mkdir_p!("node_modules/required")
+
+    output =
+      capture_io(fn ->
+        assert :ok = Mix.Tasks.Npm.Verify.run([])
+      end)
+
+    assert output =~ "node_modules matches lockfile (1 packages)"
+    refute output =~ "missing:"
+  end
+
+  test "accepts an installed platform-incompatible optional package" do
+    optional = "verify-installed-optional-#{System.unique_integer([:positive])}"
+    put_incompatible_packument!(optional, "1.0.0")
+
+    write_lockfile!(%{
+      "required" => lock_entry(optional_dependencies: %{optional => "1.0.0"}),
+      optional => lock_entry(optional: true)
+    })
+
+    File.mkdir_p!("node_modules/required")
+    File.mkdir_p!(Path.join("node_modules", optional))
+
+    output =
+      capture_io(fn ->
+        assert :ok = Mix.Tasks.Npm.Verify.run([])
+      end)
+
+    assert output =~ "node_modules matches lockfile (1 packages)"
+    refute output =~ "extra:"
+  end
+
+  test "raises when a required package is missing" do
+    write_lockfile!(%{"required" => lock_entry()})
+
+    output =
+      capture_io(:stderr, fn ->
+        assert_raise Mix.Error, ~r/node_modules does not match lockfile/, fn ->
+          Mix.Tasks.Npm.Verify.run([])
+        end
+      end)
+
+    assert output =~ "missing: required"
+  end
+
+  test "raises when an extraneous package is installed" do
+    write_lockfile!(%{"required" => lock_entry()})
+    File.mkdir_p!("node_modules/required")
+    File.mkdir_p!("node_modules/extra")
+
+    output =
+      capture_io(:stderr, fn ->
+        assert_raise Mix.Error, ~r/node_modules does not match lockfile/, fn ->
+          Mix.Tasks.Npm.Verify.run([])
+        end
+      end)
+
+    assert output =~ "extra: extra"
+  end
+
+  test "raises when the lockfile cannot be read" do
+    File.mkdir_p!("package-lock.json")
+
+    assert_raise Mix.Error, ~r/npm\.verify failed: :eisdir/, fn ->
+      Mix.Tasks.Npm.Verify.run([])
+    end
+  end
+
+  defp write_lockfile!(lockfile) do
+    assert :ok = NPM.Lockfile.write(lockfile)
+  end
+
+  defp lock_entry(opts \\ []) do
+    %{
+      version: "1.0.0",
+      integrity: "",
+      tarball: "https://registry.npmjs.org/verify-test/-/verify-test-1.0.0.tgz",
+      dependencies: %{},
+      optional_dependencies: Keyword.get(opts, :optional_dependencies, %{}),
+      has_install_script: false
+    }
+    |> maybe_put_optional(Keyword.get(opts, :optional, false))
+  end
+
+  defp put_incompatible_packument!(package, version) do
+    other_os = if NPM.Platform.current_os() == "darwin", do: "linux", else: "darwin"
+
+    NPM.PackumentCache.put(package, %{
+      name: package,
+      versions: %{
+        version => %{
+          os: [other_os],
+          cpu: [],
+          dependencies: %{},
+          optional_dependencies: %{},
+          dist: %{tarball: "", integrity: ""}
+        }
+      }
+    })
+  end
+
+  defp maybe_put_optional(entry, true), do: Map.put(entry, :optional, true)
+  defp maybe_put_optional(entry, false), do: entry
+end


### PR DESCRIPTION
## Summary
- ignore platform-skipped optional dependencies when checking missing packages
- fail `npm.verify` for missing, extraneous, and unreadable installation state
- add task-level regression coverage for optional, missing, extra, and read-failure cases

## Validation
- `mix format --check-formatted lib/mix/tasks/npm.verify.ex test/mix/tasks/npm_verify_test.exs`
- `mix compile --warnings-as-errors`
- `mix test` (57 tests, 0 failures)

Fixes #121