### PR TITLE
fix: build portable QuickBEAM NIFs

### DIFF
--- a/.github/workflows/native-prebuild.yml
+++ b/.github/workflows/native-prebuild.yml
@@ -192,14 +192,29 @@ jobs:
       matrix:
         target:
           - target: aarch64-linux-gnu
+            arch: aarch64
+            os_tag: linux
+            abi: gnu
             os: ubuntu-22.04
           - target: aarch64-macos-none
+            arch: aarch64
+            os_tag: macos
+            abi: none
             os: macos-15
           - target: x86_64-freebsd-none
+            arch: x86_64
+            os_tag: freebsd
+            abi: none
             os: ubuntu-22.04
           - target: x86_64-linux-gnu
+            arch: x86_64
+            os_tag: linux
+            abi: gnu
             os: ubuntu-22.04
           - target: x86_64-macos-none
+            arch: x86_64
+            os_tag: macos
+            abi: none
             os: macos-15-intel
 
     steps:
@@ -232,11 +247,32 @@ jobs:
         env:
           QUICKBEAM_BUILD: '1'
           DUSKMOON_BUILD_NATIVE_FROM_SOURCE: '1'
+          # Keep same-host builds from inheriting the runner's CPU features.
+          TARGET_ARCH: ${{ matrix.target.arch }}
+          TARGET_OS: ${{ matrix.target.os_tag }}
+          TARGET_ABI: ${{ matrix.target.abi }}
         run: |
           mix zigler_precompiled.build lib/quickbeam/native.ex \
             --target ${{ matrix.target.target }} \
             --version ${{ inputs.version }} \
             --out ../../artifacts
+
+      - name: Verify portable x86_64 instruction baseline
+        if: matrix.target.target == 'x86_64-linux-gnu'
+        run: |
+          set -euo pipefail
+
+          inspect_dir="$(mktemp -d)"
+          trap 'rm -rf "${inspect_dir}"' EXIT
+
+          tar xzf artifacts/Elixir.QuickBEAM.Native-v${{ inputs.version }}-x86_64-linux-gnu.so.tar.gz \
+            -C "${inspect_dir}"
+          objdump -d "${inspect_dir}/Elixir.QuickBEAM.Native.so" > "${inspect_dir}/disassembly"
+
+          if grep -Eq '%[yz]mm' "${inspect_dir}/disassembly"; then
+            echo "QuickBEAM x86_64 artifact contains AVX or AVX-512 instructions" >&2
+            exit 1
+          fi
 
       - name: Upload artifact to GitHub Release
         uses: softprops/action-gh-release@v3

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -96,8 +96,7 @@ defmodule NPM.Install.Linker do
       nested_lockfile
       |> Enum.group_by(fn {location, _entry} -> location_depth(location) end)
       |> Enum.sort_by(&elem(&1, 0))
-      |> Enum.reduce_while({:ok, MapSet.new()}, fn {_depth, entries},
-                                                   {:ok, skipped_locations} ->
+      |> Enum.reduce_while({:ok, MapSet.new()}, fn {_depth, entries}, {:ok, skipped_locations} ->
         case link_nested_depth(entries, nm_dir, strategy, flat_skipped, skipped_locations) do
           {:ok, new_skipped} -> {:cont, {:ok, new_skipped}}
           {:error, reason} -> {:halt, {:error, reason}}

--- a/apps/duskmoon_quickbeam/CHANGELOG.md
+++ b/apps/duskmoon_quickbeam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Build precompiled NIFs for an explicit CPU baseline so x86_64 artifacts run without AVX-512.
+
 ## 0.10.18
 
 - Update `oxc` to 0.17.1.


### PR DESCRIPTION
## Summary
- force explicit Zig target metadata for every QuickBEAM precompile so same-host builds use the generic CPU baseline
- reject x86_64 release artifacts that contain AVX or AVX-512 vector instructions
- document the portable native build fix

## Validation
- released v9.9.4 artifact: 4,169 YMM/ZMM instructions detected
- rebuilt artifact: zero YMM/ZMM instructions
- `QuickBEAM.start(apis: false)` starts and stops successfully with the rebuilt artifact
- `actionlint .github/workflows/native-prebuild.yml`

Fixes #123
Fixes #125