### PR TITLE
fix(bundler): preserve CommonJS singletons across dynamic imports

### DIFF
--- a/apps/duskmoon_bundler/CHANGELOG.md
+++ b/apps/duskmoon_bundler/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `json_codec` as a runtime dependency.
 
 ### Fixed
+- Production builds now fall back to a single bundle when code splitting would move a CommonJS dependency across chunks, preserving singleton packages such as React and preventing unresolved `react-dom/client` imports.
 - ESM code-split builds now rewrite Rolldown-normalized cross-chunk npm imports to emitted chunk URLs instead of leaving package specifiers in the output.
 - Generated installs now start `:duskmoon_bundler` in test, ensuring endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.
 - HMR websocket no longer drops idle connections after 60 seconds. The browser client now sends a periodic `{"type":"ping"}` heartbeat, and the server replies with `{"type":"pong"}`, preventing Bandit's websocket `read_timeout` from closing an otherwise idle socket. The client also tracks pongs and force-reconnects if the link goes half-open. This eliminates the spurious `[DuskmoonBundler] Disconnected. Reconnecting...` console noise observed on long-lived demo/dev pages with no file changes.

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
@@ -191,7 +191,8 @@ defmodule DuskmoonBundler.Builder do
 
       use_chunks =
         code_splitting and
-          (has_dynamic_imports?(dep_map) or build_ctx.chunks != %{})
+          (has_dynamic_imports?(dep_map) or build_ctx.chunks != %{}) and
+          not has_cross_chunk_require?(entry, modules, dep_map, build_ctx.chunks)
 
       if use_chunks do
         Output.build_chunks(entry, name, compiled, {modules, dep_map}, out)
@@ -221,6 +222,22 @@ defmodule DuskmoonBundler.Builder do
 
   defp has_dynamic_imports?(dep_map) do
     Enum.any?(dep_map, fn {_, %{dynamic: dyn}} -> dyn != [] end)
+  end
+
+  defp has_cross_chunk_require?(entry, modules, dep_map, manual_chunks) do
+    graph =
+      DuskmoonBundler.ChunkGraph.build(entry, modules, dep_map, manual_chunks: manual_chunks)
+
+    Enum.any?(dep_map, fn {importer, deps} ->
+      importer_chunk = graph.module_to_chunk[importer]
+
+      Enum.any?(Map.get(deps, :requires, []), fn dependency ->
+        dependency_chunk = graph.module_to_chunk[dependency]
+
+        is_binary(importer_chunk) and is_binary(dependency_chunk) and
+          importer_chunk != dependency_chunk
+      end)
+    end)
   end
 
   defp build_worker_results(workers, ctx, build_ctx) do

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/collector.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/collector.ex
@@ -8,7 +8,7 @@ defmodule DuskmoonBundler.Builder.Collector do
 
   Returns `{:ok, modules, dep_map, workers}` where:
   - `modules` is `[{abs_path, label, source}]` in dependency order
-  - `dep_map` is `%{abs_path => %{static: [abs_path], dynamic: [abs_path]}}`
+  - `dep_map` tracks static, dynamic, and CommonJS dependencies by absolute path
   - `workers` is `%{importer_path => %{specifier => worker_abs_path}}`
   """
   def collect(entry_path, ctx) do
@@ -100,10 +100,10 @@ defmodule DuskmoonBundler.Builder.Collector do
            state.ctx.plugins,
            graph_source != source
          ) do
-      {:ok, %{imports: typed_imports, workers: worker_specs}} ->
+      {:ok, %{imports: typed_imports, requires: requires, workers: worker_specs}} ->
         state = %{
           state
-          | dep_map: Map.put(state.dep_map, abs_path, split_imports(typed_imports))
+          | dep_map: Map.put(state.dep_map, abs_path, split_imports(typed_imports, requires))
         }
 
         {state, worker_specs} = resolve_workers(worker_specs, abs_path, state)
@@ -179,7 +179,8 @@ defmodule DuskmoonBundler.Builder.Collector do
         deps = %{
           deps
           | static: replace_specifier(deps.static, specifier, resolved_path),
-            dynamic: replace_specifier(deps.dynamic, specifier, resolved_path)
+            dynamic: replace_specifier(deps.dynamic, specifier, resolved_path),
+            requires: replace_specifier(deps.requires, specifier, resolved_path)
         }
 
         Map.put(dep_map, importer, deps)
@@ -343,7 +344,7 @@ defmodule DuskmoonBundler.Builder.Collector do
     end
   end
 
-  defp split_imports(typed_imports) do
+  defp split_imports(typed_imports, requires) do
     {statics, dynamics} =
       Enum.reduce(typed_imports, {[], []}, fn
         {:static, spec}, {s, d} -> {[spec | s], d}
@@ -352,7 +353,8 @@ defmodule DuskmoonBundler.Builder.Collector do
 
     %DuskmoonBundler.Builder.Dependencies{
       static: Enum.reverse(statics),
-      dynamic: Enum.reverse(dynamics)
+      dynamic: Enum.reverse(dynamics),
+      requires: requires
     }
   end
 end

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/collector/dependencies.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/collector/dependencies.ex
@@ -1,5 +1,5 @@
 defmodule DuskmoonBundler.Builder.Dependencies do
-  @moduledoc "Static and dynamic dependency lists for one collected module."
+  @moduledoc "Static, dynamic, and CommonJS dependency lists for one collected module."
 
-  defstruct static: [], dynamic: []
+  defstruct static: [], dynamic: [], requires: []
 end

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/imports/extractor.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/imports/extractor.ex
@@ -9,15 +9,22 @@ defmodule DuskmoonBundler.JS.ImportExtractor do
     with {:ok, imports} <- OXC.select(source, filename, :import_sources),
          {:ok, require_calls} <- select_require_calls(source, filename, opts),
          {:ok, workers} <- select_workers(source, filename) do
-      typed = Enum.map(imports, &{&1.type, &1.specifier}) ++ require_calls
-      {:ok, %DuskmoonBundler.JS.ImportExtractor.Result{imports: typed, workers: workers}}
+      requires = Enum.map(require_calls, & &1.specifier)
+      typed = Enum.map(imports, &{&1.type, &1.specifier}) ++ Enum.map(requires, &{:static, &1})
+
+      {:ok,
+       %DuskmoonBundler.JS.ImportExtractor.Result{
+         imports: typed,
+         requires: requires,
+         workers: workers
+       }}
     end
   end
 
   defp select_require_calls(source, filename, opts) do
     if Keyword.get(opts, :include_require, false) do
       case OXC.select(source, filename, :require_calls) do
-        {:ok, require_calls} -> {:ok, Enum.map(require_calls, &{:static, &1.specifier})}
+        {:ok, require_calls} -> {:ok, require_calls}
         {:error, _} = error -> error
       end
     else

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/imports/result.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/imports/result.ex
@@ -2,7 +2,11 @@ defmodule DuskmoonBundler.JS.ImportExtractor.Result do
   @moduledoc "Structured result returned by JavaScript import extraction."
 
   @type import_type :: :static | :dynamic
-  @type t :: %__MODULE__{imports: [{import_type(), String.t()}], workers: [String.t()]}
+  @type t :: %__MODULE__{
+          imports: [{import_type(), String.t()}],
+          requires: [String.t()],
+          workers: [String.t()]
+        }
 
-  defstruct imports: [], workers: []
+  defstruct imports: [], requires: [], workers: []
 end

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -1475,6 +1475,67 @@ defmodule DuskmoonBundler.BuilderTest do
       refute js =~ ~r/\brequire\s*\(/
     end
 
+    test "resolves shared React imports from nested react-dom modules when code splitting" do
+      File.mkdir_p!(Path.join(@fixture_dir, "node_modules/react"))
+      File.mkdir_p!(Path.join(@fixture_dir, "node_modules/react-dom/cjs"))
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react/package.json"),
+        ~s({"name":"react","main":"index.js"})
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react/index.js"),
+        "const singleton = 'react-singleton'; exports.createElement = function() { return 'react-element' }; exports.useState = function() { return singleton }\n"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react-dom/package.json"),
+        ~s({"name":"react-dom","exports":{"./client":"./client.js"}})
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react-dom/client.js"),
+        "module.exports = require('./cjs/react-dom-client.production.js')\n"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react-dom/cjs/react-dom-client.production.js"),
+        "var React = require('react'); exports.createRoot = function() { return React }\n"
+      )
+
+      File.write!(Path.join(@fixture_dir, "src/react_component.ts"), """
+      import { createElement, useState } from 'react'
+      export function ReproComponent() { return createElement('p', null, useState()) }
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/react_app.ts"), """
+      import { createElement } from 'react'
+      import { createRoot } from 'react-dom/client'
+      const root = createRoot()
+      void import('./react_component').then(({ ReproComponent }) => {
+        root.render(createElement(ReproComponent))
+      })
+      """)
+
+      assert {:ok, result} =
+               DuskmoonBundler.Builder.build(
+                 entry: Path.join(@fixture_dir, "src/react_app.ts"),
+                 outdir: @outdir,
+                 minify: true,
+                 sourcemap: false,
+                 node_modules: Path.join(@fixture_dir, "node_modules")
+               )
+
+      assert result.chunks == []
+
+      js = File.read!(result.js.path)
+      assert js =~ "react-element"
+      assert js =~ "ReproComponent"
+      assert length(Regex.scan(~r/react-singleton/, js)) == 1
+      refute js =~ ~r/\brequire\s*\(/, js
+    end
+
     test "resolves package subpath without exports field" do
       File.mkdir_p!(Path.join(@fixture_dir, "node_modules/subpath-pkg/lib"))
 


### PR DESCRIPTION
## Summary
- track literal CommonJS dependency edges alongside static imports
- fall back to a single production bundle only when a `require()` edge would cross chunk boundaries
- cover the React 19 `react-dom/client` dynamic-import regression with a singleton-sensitive fixture

## Validation
- `mix test apps/duskmoon_bundler/test`
- `mix compile --warnings-as-errors`
- scoped `mix format --check-formatted`

Fixes #124