### PR TITLE
fix(npm): default registry installs to copies

### DIFF
--- a/apps/duskmoon_npm/CHANGELOG.md
+++ b/apps/duskmoon_npm/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Propagate non-zero exit codes from `mix npm.run` and `mix npm.exec` to the shell
 - Accept lockfiles without a policy section in `--frozen` install
 - Include `optionalDependencies` in lockfile consistency check for `--frozen` install
+- Default registry package installs to copies and relink legacy cache symlinks so ESM package binaries resolve sibling dependencies from project `node_modules`
 
 ## 0.7.3
 

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -387,10 +387,11 @@ defmodule NPM do
   defp node_modules_intact?(lockfile, local_links) do
     skipped = Linker.skipped_packages(lockfile)
     linkable_lockfile = linkable_lockfile(lockfile, skipped)
+    strategy = Linker.strategy()
 
     lockfile_intact? =
       Enum.all?(linkable_lockfile, fn {name, _entry} ->
-        registry_package_intact?(name)
+        registry_package_intact?(Path.join(@node_modules, name), strategy)
       end)
 
     local_links_intact? =
@@ -403,7 +404,7 @@ defmodule NPM do
         {:ok, nested_lockfile} ->
           Enum.all?(nested_lockfile, fn {location, _entry} ->
             nested_location_skipped?(location, skipped) or
-              Path.join(location, "package.json") |> File.exists?()
+              registry_package_intact?(location, strategy)
           end)
 
         {:error, _reason} ->
@@ -506,11 +507,12 @@ defmodule NPM do
     Enum.reject(lockfile, fn {name, _entry} -> MapSet.member?(skipped, name) end)
   end
 
-  defp registry_package_intact?(name) do
-    package_dir = Path.join(@node_modules, name)
-
+  defp registry_package_intact?(package_dir, strategy) do
     case File.lstat(package_dir) do
-      {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
+      {:ok, %File.Stat{type: :directory}} ->
+        File.exists?(Path.join(package_dir, "package.json"))
+
+      {:ok, %File.Stat{type: :symlink}} when strategy == :symlink ->
         File.exists?(Path.join(package_dir, "package.json"))
 
       _ ->

--- a/apps/duskmoon_npm/lib/npm/install/linker.ex
+++ b/apps/duskmoon_npm/lib/npm/install/linker.ex
@@ -561,8 +561,8 @@ defmodule NPM.Install.Linker do
     case System.get_env("NPM_EX_LINK_STRATEGY") do
       "copy" -> :copy
       "symlink" -> :symlink
-      nil -> :symlink
-      _ -> :symlink
+      nil -> :copy
+      _ -> :copy
     end
   end
 

--- a/apps/duskmoon_npm/test/npm/install/linker_test.exs
+++ b/apps/duskmoon_npm/test/npm/install/linker_test.exs
@@ -6,6 +6,8 @@ defmodule NPM.Install.LinkerTest do
 
   setup do
     old_cache_dir = Application.get_env(:duskmoon_npm, :cache_dir)
+    old_link_strategy = System.get_env("NPM_EX_LINK_STRATEGY")
+    System.delete_env("NPM_EX_LINK_STRATEGY")
 
     tmp_dir =
       Path.join([
@@ -20,10 +22,23 @@ defmodule NPM.Install.LinkerTest do
 
     on_exit(fn ->
       restore_app_env(:cache_dir, old_cache_dir)
+      restore_system_env("NPM_EX_LINK_STRATEGY", old_link_strategy)
       File.rm_rf!(tmp_dir)
     end)
 
     {:ok, tmp_dir: tmp_dir}
+  end
+
+  describe "strategy/0" do
+    test "defaults to copy and preserves explicit symlink opt-in" do
+      assert Linker.strategy() == :copy
+
+      System.put_env("NPM_EX_LINK_STRATEGY", "symlink")
+      assert Linker.strategy() == :symlink
+
+      System.put_env("NPM_EX_LINK_STRATEGY", "invalid")
+      assert Linker.strategy() == :copy
+    end
   end
 
   describe "__parent_entry_version__/1" do
@@ -75,10 +90,8 @@ defmodule NPM.Install.LinkerTest do
     installed_importer = Path.join(node_modules, importer)
     installed_sibling = Path.join(node_modules, sibling)
 
-    assert {:ok, %File.Stat{type: importer_type}} = File.lstat(installed_importer)
-    assert {:ok, %File.Stat{type: sibling_type}} = File.lstat(installed_sibling)
-    assert importer_type in [:directory, :symlink]
-    assert sibling_type in [:directory, :symlink]
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_importer)
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_sibling)
     assert File.read!(Path.join(installed_importer, "index.js")) =~ sibling
 
     assert File.read!(Path.join(installed_importer, "package.json")) ==
@@ -241,4 +254,7 @@ defmodule NPM.Install.LinkerTest do
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)
   defp restore_app_env(key, value), do: Application.put_env(:duskmoon_npm, key, value)
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
 end

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -6,6 +6,8 @@ defmodule NPM.InstallTest do
   setup do
     old_cwd = File.cwd!()
     old_cache_dir = Application.get_env(:duskmoon_npm, :cache_dir)
+    old_link_strategy = System.get_env("NPM_EX_LINK_STRATEGY")
+    System.delete_env("NPM_EX_LINK_STRATEGY")
 
     tmp_dir =
       Path.join([
@@ -24,6 +26,7 @@ defmodule NPM.InstallTest do
     on_exit(fn ->
       File.cd!(old_cwd)
       restore_app_env(:cache_dir, old_cache_dir)
+      restore_system_env("NPM_EX_LINK_STRATEGY", old_link_strategy)
       File.rm_rf!(tmp_dir)
     end)
 
@@ -60,7 +63,9 @@ defmodule NPM.InstallTest do
     )
   end
 
-  test "treats existing cache symlinks as intact", %{project_dir: project_dir} do
+  test "relinks existing cache symlinks with the default copy strategy", %{
+    project_dir: project_dir
+  } do
     package = "legacy-symlink-package"
     version = "1.0.0"
     cache_path = write_cached_package!(package, version)
@@ -84,8 +89,33 @@ defmodule NPM.InstallTest do
         assert :ok = NPM.install()
       end)
 
-    assert output =~ "Already up to date."
+    assert output =~ "Installing from current package-lock.json."
     assert_copied_package(cache_path, installed_path)
+  end
+
+  test "keeps existing cache symlinks with explicit symlink strategy", %{
+    project_dir: project_dir
+  } do
+    System.put_env("NPM_EX_LINK_STRATEGY", "symlink")
+    package = "explicit-symlink-package"
+    version = "1.0.0"
+    cache_path = write_cached_package!(package, version)
+
+    write_package!(project_dir, %{
+      "name" => "explicit_symlink_project",
+      "dependencies" => %{package => version}
+    })
+
+    assert :ok = NPM.Lockfile.write(%{package => lock_entry(package, version)})
+
+    installed_path = Path.join([project_dir, "node_modules", package])
+    File.mkdir_p!(Path.dirname(installed_path))
+    File.ln_s!(cache_path, installed_path)
+
+    output = capture_io(fn -> assert :ok = NPM.install() end)
+
+    assert output =~ "Already up to date."
+    assert_symlink_target!(installed_path, cache_path)
   end
 
   test "re-resolves a lockfile with missing transitive package records", %{
@@ -568,8 +598,7 @@ defmodule NPM.InstallTest do
   end
 
   defp assert_copied_package(cache_path, installed_path) do
-    assert {:ok, %File.Stat{type: type}} = File.lstat(installed_path)
-    assert type in [:directory, :symlink]
+    assert {:ok, %File.Stat{type: :directory}} = File.lstat(installed_path)
 
     assert File.read!(Path.join(installed_path, "package.json")) ==
              File.read!(Path.join(cache_path, "package.json"))
@@ -597,4 +626,7 @@ defmodule NPM.InstallTest do
 
   defp restore_app_env(key, nil), do: Application.delete_env(:duskmoon_npm, key)
   defp restore_app_env(key, value), do: Application.put_env(:duskmoon_npm, key, value)
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
 end


### PR DESCRIPTION
## Summary
- restore copy as the default registry package link strategy while preserving explicit symlink opt-in
- migrate legacy cache symlinks for default-copy installs, including nested registry packages
- add focused default, migration, and explicit-symlink regression coverage

## Validation
- `mix test apps/duskmoon_npm/test` (59 tests, 0 failures)
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`

Fixes #129