### PR TITLE
fix: retain multi-select values

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/select.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/select.ex
@@ -134,7 +134,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Select do
   defp render_options(%{options: options} = assigns) when is_list(options) do
     ~H"""
     <option :if={@prompt} value="">{@prompt}</option>
-    <option :for={{value, label} <- @options} value={value} selected={@value == value}>
+    <option :for={{value, label} <- @options} value={value} selected={selected?(@value, value)}>
       {label}
     </option>
     """
@@ -146,4 +146,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Select do
     {render_slot(@inner_block)}
     """
   end
+
+  defp selected?(values, value) when is_list(values), do: value in values
+  defp selected?(selected_value, value), do: selected_value == value
 end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/select_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/select_test.exs
@@ -195,6 +195,20 @@ defmodule PhoenixDuskmoon.Component.DataEntry.SelectTest do
     assert result =~ "Blue"
   end
 
+  test "selects options whose values are in the multiple value list" do
+    result =
+      render_component(&dm_select/1, %{
+        name: "labels[]",
+        value: ["bug", "feature"],
+        multiple: true,
+        options: [{"bug", "Bug"}, {"docs", "Documentation"}, {"feature", "Feature"}]
+      })
+
+    assert result =~ ~r/<option value="bug" selected(?:="selected")?>/
+    refute result =~ ~r/<option value="docs" selected(?:="selected")?>/
+    assert result =~ ~r/<option value="feature" selected(?:="selected")?>/
+  end
+
   test "renders select with label_class" do
     result =
       render_component(&dm_select/1, %{


### PR DESCRIPTION
## Summary
- select list-valued options by membership for multiple selects
- preserve scalar equality for single selects
- add regression coverage for selected and unselected multiple values

Fixes #131