### PR TITLE
fix: preserve exports across production chunks

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
@@ -423,6 +423,7 @@ defmodule DuskmoonBundler.Builder.Output do
         {:cont, {:ok, acc}}
       else
         chunk_js = Rewriter.rewrite_external_imports(chunk_js, ctx)
+        chunk_js = add_chunk_facade(chunk_js, chunk_id, chunk)
         {chunk_js, dynamic_import_placeholder} = Rewriter.protect_dynamic_imports(chunk_js)
 
         external =
@@ -475,6 +476,37 @@ defmodule DuskmoonBundler.Builder.Output do
   end
 
   defp chunk_entry_label([{label, _code} | _]), do: label
+
+  defp add_chunk_facade([_single] = js_files, _chunk_id, _chunk), do: js_files
+
+  defp add_chunk_facade(js_files, chunk_id, %{type: type}) when type in [:common, :manual] do
+    {first_label, _code} = hd(js_files)
+    facade_label = Path.join(Path.dirname(first_label), "__duskmoon_#{chunk_id}_entry__.js")
+
+    exports =
+      Enum.map_join(js_files, "\n", fn {label, _code} ->
+        specifier = module_specifier(facade_label, label)
+        "export * from #{Jason.encode!(specifier)};"
+      end)
+
+    default_export =
+      Enum.find_value(js_files, fn {label, code} ->
+        if default_export?(code) do
+          "export { default } from #{Jason.encode!(module_specifier(facade_label, label))};\n"
+        end
+      end)
+
+    [{facade_label, (default_export || "") <> exports} | js_files]
+  end
+
+  defp add_chunk_facade(js_files, _chunk_id, _chunk), do: js_files
+
+  defp default_export?(code) do
+    case OXC.parse(code, "chunk.js") do
+      {:ok, ast} -> Enum.any?(ast.body, &(&1.type == :export_default_declaration))
+      {:error, _} -> false
+    end
+  end
 
   defp select_chunk_files(module_paths, js_map, module_labels) do
     module_paths

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -657,6 +657,85 @@ defmodule DuskmoonBundler.BuilderTest do
       refute manifest["dynamic-entry-lazy.js"]["isEntry"]
     end
 
+    test "code splitting keeps every export from disconnected common modules" do
+      File.write!(
+        Path.join(@fixture_dir, "src/shared-default.ts"),
+        "export default 'default-value'"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "src/shared-schema.ts"),
+        "export const defaultSchema = 'schema-value'"
+      )
+
+      for name <- ["one", "two"] do
+        File.write!(Path.join(@fixture_dir, "src/lazy-#{name}.ts"), """
+        import sharedDefault from './shared-default'
+        import { defaultSchema } from './shared-schema'
+        export const value = '#{name}-' + sharedDefault + '-' + defaultSchema
+        """)
+      end
+
+      File.write!(Path.join(@fixture_dir, "src/common_exports_entry.ts"), """
+      export const loadOne = () => import('./lazy-one').then((mod) => mod.value)
+      export const loadTwo = () => import('./lazy-two').then((mod) => mod.value)
+      """)
+
+      {:ok, result} =
+        DuskmoonBundler.Builder.build(
+          entry: Path.join(@fixture_dir, "src/common_exports_entry.ts"),
+          outdir: @outdir,
+          name: "common-exports",
+          format: :esm,
+          hash: false,
+          minify: true,
+          sourcemap: false
+        )
+
+      node = System.find_executable("node") || flunk("node executable not found")
+      entry_url = "file://#{result.js.path}"
+
+      assert {output, 0} =
+               System.cmd(
+                 node,
+                 [
+                   "--input-type=module",
+                   "--eval",
+                   "globalThis.document = { querySelector: () => null, createElement: () => ({}), head: { appendChild: () => {} } }; globalThis.window = { dispatchEvent: () => {} }; globalThis.CustomEvent = class {}; const m = await import('#{entry_url}'); console.log(await m.loadOne()); console.log(await m.loadTwo())"
+                 ],
+                 env: [{"NODE_NO_WARNINGS", "1"}],
+                 stderr_to_stdout: true
+               )
+
+      assert output == "one-default-value-schema-value\ntwo-default-value-schema-value\n"
+    end
+
+    test "no code splitting inlines literal dynamic imports" do
+      File.write!(
+        Path.join(@fixture_dir, "src/no_split_lazy.ts"),
+        "export const value = 'inlined'"
+      )
+
+      File.write!(Path.join(@fixture_dir, "src/no_split_entry.ts"), """
+      export const load = () => import('./no_split_lazy').then((mod) => mod.value)
+      """)
+
+      assert {:ok, result} =
+               DuskmoonBundler.Builder.build(
+                 entry: Path.join(@fixture_dir, "src/no_split_entry.ts"),
+                 outdir: @outdir,
+                 name: "no-split",
+                 format: :esm,
+                 hash: false,
+                 minify: true,
+                 sourcemap: false,
+                 code_splitting: false
+               )
+
+      assert result.chunks == []
+      assert File.read!(result.js.path) =~ "inlined"
+    end
+
     test "code splitting records async chunk css in manifest and preloads it" do
       File.write!(Path.join(@fixture_dir, "src/lazy.css"), ".lazy { color: red }")
 

--- a/apps/duskmoon_oxc/native/oxc_ex_nif/src/bundle.rs
+++ b/apps/duskmoon_oxc/native/oxc_ex_nif/src/bundle.rs
@@ -11,7 +11,8 @@ use rolldown::{
     TreeshakeOptions,
 };
 use rolldown_common::{
-    AssetFilenamesOutputOption, ChunkFilenamesOutputOption, ModuleType, Output, StrOrBytes,
+    AssetFilenamesOutputOption, ChunkFilenamesOutputOption, CodeSplittingMode, ModuleType, Output,
+    StrOrBytes,
 };
 use rustc_hash::FxHashMap;
 use rustler::{Binary, Encoder, Env, Error, ListIterator, NifMap, NifResult, SerdeTerm, Term};
@@ -271,12 +272,15 @@ fn build_bundle_options(
     external_specifiers: Vec<String>,
     file: Option<String>,
 ) -> BundlerOptions {
+    let code_splitting = file.is_some().then_some(CodeSplittingMode::Bool(false));
+
     BundlerOptions {
         input: Some(input),
         cwd: Some(cwd.to_path_buf()),
         external: (!external_specifiers.is_empty()).then(|| IsExternal::from(external_specifiers)),
         dir: opts.outdir.clone(),
         file,
+        code_splitting,
         format: Some(match opts.format.as_str() {
             "esm" => OutputFormat::Esm,
             "cjs" => OutputFormat::Cjs,


### PR DESCRIPTION
## Summary
- emit explicit facades for shared and manual chunks so every bundled module export is available to generated bridge chunks
- disable Rolldown code splitting whenever the OXC single-file API selects `output.file`, allowing literal dynamic imports to be inlined
- cover the production linker failure through Node module loading and the `--no-code-splitting` fallback

## Validation
- `mix test apps/duskmoon_bundler/test apps/duskmoon_oxc/test/oxc/bundle_test.exs` (2 doctests, 446 tests total, 0 failures)
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `cargo fmt --manifest-path apps/duskmoon_oxc/native/oxc_ex_nif/Cargo.toml -- --check`

Fixes #134