### PR TITLE
fix: publish TypeScript hook declarations

### DIFF
--- a/apps/phoenix_duskmoon/assets/js/hooks/index.d.ts
+++ b/apps/phoenix_duskmoon/assets/js/hooks/index.d.ts
@@ -1,0 +1,45 @@
+export type HookEventPayload = unknown;
+
+export type HookEventCallback = (reply: unknown, ref: number) => void;
+
+/** The LiveView-owned context supplied as `this` to hook callbacks. */
+export interface LiveViewHookContext<ElementType extends HTMLElement = HTMLElement> {
+	readonly el: ElementType;
+	handleEvent(
+		event: string,
+		callback: (payload: HookEventPayload) => void,
+	): unknown;
+	pushEvent(
+		event: string,
+		payload?: HookEventPayload,
+		callback?: HookEventCallback,
+	): unknown;
+	pushEventTo(
+		target: string | number | HTMLElement,
+		event: string,
+		payload?: HookEventPayload,
+		callback?: HookEventCallback,
+	): unknown;
+}
+
+/** A Phoenix LiveView hook definition object. */
+export interface LiveViewHook<ElementType extends HTMLElement = HTMLElement> {
+	mounted?(this: LiveViewHookContext<ElementType>): void;
+	updated?(this: LiveViewHookContext<ElementType>): void;
+	destroyed?(this: LiveViewHookContext<ElementType>): void;
+}
+
+/** Universal LiveView to custom-element event bridge. */
+export declare const WebComponentHook: LiveViewHook;
+
+/** WebComponentHook with Phoenix form-feedback integration. */
+export declare const FormElementHook: LiveViewHook;
+
+/** Theme toggle with localStorage persistence. */
+export declare const ThemeSwitcher: LiveViewHook<HTMLDetailsElement>;
+
+/** Cmd/Ctrl+K spotlight dialog keyboard handler. */
+export declare const Spotlight: LiveViewHook<HTMLDialogElement>;
+
+/** Page-header visibility observer. */
+export declare const PageHeader: LiveViewHook;


### PR DESCRIPTION
## Summary
- publish an adjacent TypeScript declaration for the documented JavaScript hooks entry
- type WebComponentHook, FormElementHook, ThemeSwitcher, Spotlight, and PageHeader without adding a consumer dependency
- specialize the theme-switcher and spotlight hook element types while keeping the shared LiveView context structural

## Validation
- strict TypeScript checks pass for both the direct Hex-path import and `phoenix_duskmoon/hooks`
- declarations are assignable to Phoenix LiveView 1.2.7 `HooksOptions`
- `bun test apps/phoenix_duskmoon/test/js` (4 tests, 0 failures)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test` (3,135 tests, 0 failures)
- release-equivalent `mix prepublish` and `MIX_ENV=prod mix hex.build --unpack` include `assets/js/hooks/index.d.ts`

Fixes #137