### PR TITLE
fix: validate code-split exports

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
@@ -195,7 +195,17 @@ defmodule DuskmoonBundler.Builder do
           not has_cross_chunk_require?(entry, modules, dep_map, build_ctx.chunks)
 
       if use_chunks do
-        Output.build_chunks(entry, name, compiled, {modules, dep_map}, out)
+        case Output.build_chunks(entry, name, compiled, {modules, dep_map}, out) do
+          {:error, {:invalid_chunk_links, missing_exports}} ->
+            Logger.warning(
+              "falling back to a single bundle because code splitting produced invalid imports: #{inspect(missing_exports)}"
+            )
+
+            Output.build_single(entry, name, compiled, out)
+
+          result ->
+            result
+        end
       else
         Output.build_single(entry, name, compiled, out)
       end

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
@@ -85,6 +85,15 @@ defmodule DuskmoonBundler.Builder.Output do
              ctx,
              graph,
              dep_map
+           ),
+         :ok <-
+           validate_chunk_links(
+             chunk_bundles,
+             graph,
+             module_labels,
+             name,
+             hash,
+             dep_map
            ) do
       css_opts = Keyword.put(bundle_opts, :asset_url_prefix, asset_url_prefix)
 
@@ -158,6 +167,131 @@ defmodule DuskmoonBundler.Builder.Output do
       end
     end
   end
+
+  defp validate_chunk_links(chunk_bundles, graph, module_labels, name, hash, dep_map) do
+    url_map = chunk_url_map(chunk_bundles, graph.chunks, name, hash)
+
+    chunks =
+      Map.new(chunk_bundles, fn {chunk_id, {code, _sourcemap}} ->
+        chunk = graph.chunks[chunk_id]
+        import_map = chunk_import_map(chunk, graph, module_labels, dep_map)
+        code = Rewriter.rewrite_chunk_imports(code, import_map, url_map)
+        {"./#{url_map[chunk_id]}", code}
+      end)
+
+    exports = Map.new(chunks, fn {url, code} -> {url, chunk_exports(code)} end)
+
+    missing_exports =
+      Enum.flat_map(chunks, fn {url, code} -> missing_chunk_exports(url, code, exports) end)
+      |> Enum.uniq()
+
+    if missing_exports == [] do
+      :ok
+    else
+      {:error, {:invalid_chunk_links, missing_exports}}
+    end
+  end
+
+  defp chunk_exports(code) do
+    case OXC.parse(code, "chunk.js") do
+      {:ok, ast} ->
+        Enum.reduce(ast.body, {MapSet.new(), false}, fn
+          %{type: :export_default_declaration}, {exports, wildcard?} ->
+            {MapSet.put(exports, "default"), wildcard?}
+
+          %{type: :export_named_declaration, specifiers: specifiers, declaration: declaration},
+          {exports, wildcard?} ->
+            names = Enum.map(specifiers, &ast_name(&1.exported)) ++ declaration_names(declaration)
+            {Enum.reduce(names, exports, &MapSet.put(&2, &1)), wildcard?}
+
+          %{type: :export_all_declaration}, {exports, _wildcard?} ->
+            {exports, true}
+
+          _node, acc ->
+            acc
+        end)
+
+      {:error, _errors} ->
+        {MapSet.new(), false}
+    end
+  end
+
+  defp missing_chunk_exports(importer, code, exports) do
+    case OXC.parse(code, "chunk.js") do
+      {:ok, ast} ->
+        Enum.flat_map(ast.body, fn
+          %{type: :import_declaration, source: %{value: source}, specifiers: specifiers}
+          when is_binary(source) ->
+            missing_import_specifiers(importer, source, specifiers, exports)
+
+          %{type: :export_named_declaration, source: %{value: source}, specifiers: specifiers}
+          when is_binary(source) ->
+            missing_export_specifiers(importer, source, specifiers, exports)
+
+          _node ->
+            []
+        end)
+
+      {:error, errors} ->
+        [{importer, :parse_error, errors}]
+    end
+  end
+
+  defp missing_import_specifiers(importer, source, specifiers, exports) do
+    required =
+      Enum.flat_map(specifiers, fn
+        %{type: :import_default_specifier} -> ["default"]
+        %{type: :import_specifier, imported: imported} -> [ast_name(imported)]
+        %{type: :import_namespace_specifier} -> []
+        _specifier -> []
+      end)
+
+    missing_names(importer, source, required, exports)
+  end
+
+  defp missing_export_specifiers(importer, source, specifiers, exports) do
+    required = Enum.map(specifiers, &ast_name(&1.local))
+    missing_names(importer, source, required, exports)
+  end
+
+  defp missing_names(importer, source, required, exports) do
+    case Map.fetch(exports, source) do
+      {:ok, {available, false}} ->
+        required
+        |> Enum.reject(&MapSet.member?(available, &1))
+        |> Enum.map(&{importer, source, &1})
+
+      _missing_or_wildcard ->
+        []
+    end
+  end
+
+  defp declaration_names(nil), do: []
+  defp declaration_names(%{id: id}) when not is_nil(id), do: [ast_name(id)]
+
+  defp declaration_names(%{declarations: declarations}) do
+    Enum.flat_map(declarations, fn %{id: id} -> pattern_names(id) end)
+  end
+
+  defp declaration_names(_declaration), do: []
+
+  defp pattern_names(%{type: :identifier} = identifier), do: [ast_name(identifier)]
+  defp pattern_names(%{elements: elements}), do: Enum.flat_map(elements, &pattern_names/1)
+
+  defp pattern_names(%{properties: properties}) do
+    Enum.flat_map(properties, fn
+      %{value: value} -> pattern_names(value)
+      %{argument: argument} -> pattern_names(argument)
+      _property -> []
+    end)
+  end
+
+  defp pattern_names(%{argument: argument}), do: pattern_names(argument)
+  defp pattern_names(nil), do: []
+  defp pattern_names(_pattern), do: []
+
+  defp ast_name(%{name: name}) when is_binary(name), do: name
+  defp ast_name(%{value: value}) when is_binary(value), do: value
 
   defp finalize_chunk_urls(
          chunk_bundles,

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -710,6 +710,65 @@ defmodule DuskmoonBundler.BuilderTest do
       assert output == "one-default-value-schema-value\ntwo-default-value-schema-value\n"
     end
 
+    test "code splitting does not emit imports for ambiguous common exports" do
+      File.write!(Path.join(@fixture_dir, "src/shared-markdown.ts"), """
+      export const html = 'markdown-html'
+      export const svg = 'markdown-svg'
+      export const stringify = 'markdown-stringify'
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/shared-renderer.ts"), """
+      export const html = 'renderer-html'
+      export const svg = 'renderer-svg'
+      export const stringify = 'renderer-stringify'
+      """)
+
+      for name <- ["one", "two"] do
+        File.write!(Path.join(@fixture_dir, "src/ambiguous-#{name}.ts"), """
+        import { html, svg, stringify } from './shared-markdown'
+        import { html as rendererHtml } from './shared-renderer'
+        export const value = '#{name}-' + html + '-' + svg + '-' + stringify + '-' + rendererHtml
+        """)
+      end
+
+      File.write!(Path.join(@fixture_dir, "src/ambiguous_exports_entry.ts"), """
+      export const loadOne = () => import('./ambiguous-one').then((mod) => mod.value)
+      export const loadTwo = () => import('./ambiguous-two').then((mod) => mod.value)
+      """)
+
+      {:ok, result} =
+        DuskmoonBundler.Builder.build(
+          entry: Path.join(@fixture_dir, "src/ambiguous_exports_entry.ts"),
+          outdir: @outdir,
+          name: "ambiguous-exports",
+          format: :esm,
+          hash: false,
+          minify: true,
+          sourcemap: false
+        )
+
+      node = System.find_executable("node") || flunk("node executable not found")
+      entry_url = "file://#{result.js.path}"
+
+      assert result.chunks == []
+
+      assert {output, 0} =
+               System.cmd(
+                 node,
+                 [
+                   "--input-type=module",
+                   "--eval",
+                   "globalThis.document = { querySelector: () => null, createElement: () => ({}), head: { appendChild: () => {} } }; globalThis.window = { dispatchEvent: () => {} }; globalThis.CustomEvent = class {}; const m = await import('#{entry_url}'); console.log(await m.loadOne()); console.log(await m.loadTwo())"
+                 ],
+                 env: [{"NODE_NO_WARNINGS", "1"}],
+                 stderr_to_stdout: true
+               )
+
+      assert output ==
+               "one-markdown-html-markdown-svg-markdown-stringify-renderer-html\n" <>
+                 "two-markdown-html-markdown-svg-markdown-stringify-renderer-html\n"
+    end
+
     test "no code splitting inlines literal dynamic imports" do
       File.write!(
         Path.join(@fixture_dir, "src/no_split_lazy.ts"),


### PR DESCRIPTION
## Summary

- validate rewritten static imports against each generated chunk export set before writing split assets
- fall back to the single-file bundle when Rolldown coalesces ambiguous exports into an invalid ESM graph
- add a Node ESM regression covering the reopened `html`, `svg`, and `stringify` collision

## Validation

- `mix test apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs` (57 tests)
- `mix test apps/duskmoon_bundler/test` (446 tests, 2 doctests)
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `git diff --check`

Fixes #134