### PR TITLE
fix: resolve package import aliases

### DIFF
--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -1321,6 +1321,53 @@ defmodule DuskmoonBundler.BuilderTest do
       assert js =~ "fake-widget"
     end
 
+    test "single bundle resolves package import aliases for browsers" do
+      package_dir = Path.join(@fixture_dir, "node_modules/package-imports-lib")
+      File.mkdir_p!(Path.join(package_dir, "lib"))
+
+      File.write!(
+        Path.join(package_dir, "package.json"),
+        ~s({"name":"package-imports-lib","type":"module","main":"index.js","imports":{"#minpath":{"node":"./lib/minpath.js","default":"./lib/minpath.browser.js"}}})
+      )
+
+      File.write!(Path.join(package_dir, "index.js"), """
+      import { minpath } from '#minpath'
+      export const platform = minpath
+      """)
+
+      File.write!(Path.join(package_dir, "lib/minpath.js"), "export const minpath = 'node'")
+
+      File.write!(
+        Path.join(package_dir, "lib/minpath.browser.js"),
+        "export const minpath = 'browser'"
+      )
+
+      File.write!(Path.join(@fixture_dir, "src/package_imports_app.ts"), """
+      import { platform } from 'package-imports-lib'
+      console.log(platform)
+      """)
+
+      {:ok, result} =
+        DuskmoonBundler.Builder.build(
+          entry: Path.join(@fixture_dir, "src/package_imports_app.ts"),
+          outdir: @outdir,
+          format: :esm,
+          hash: false,
+          minify: true,
+          sourcemap: false,
+          code_splitting: false,
+          node_modules: Path.join(@fixture_dir, "node_modules")
+        )
+
+      js = File.read!(result.js.path)
+      refute js =~ "#minpath"
+
+      node = System.find_executable("node") || flunk("node executable not found")
+
+      assert {"browser\n", 0} =
+               System.cmd(node, [result.js.path], stderr_to_stdout: true)
+    end
+
     test "minified ESM rewrites normalized cross-chunk npm imports" do
       el_base_dir =
         Path.join(@fixture_dir, "node_modules/@duskmoon-dev/el-base/dist/esm")

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/url_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/url_test.exs
@@ -24,6 +24,10 @@ defmodule DuskmoonBundler.URLTest do
       assert DuskmoonBundler.URL.split_query("/assets/app.js?raw#hash") ==
                {"/assets/app.js", "raw"}
     end
+
+    test "preserves package import specifiers" do
+      assert DuskmoonBundler.URL.split_query("#minpath") == {"#minpath", ""}
+    end
   end
 
   describe "append_query/2 and append_fragment/2" do

--- a/apps/duskmoon_bundler_runtime/lib/duskmoon_bundler/url.ex
+++ b/apps/duskmoon_bundler_runtime/lib/duskmoon_bundler/url.ex
@@ -15,6 +15,8 @@ defmodule DuskmoonBundler.URL do
     end
   end
 
+  def split_query("#" <> _ = specifier), do: {specifier, ""}
+
   def split_query(url) do
     uri = URI.parse(url)
     path = URI.to_string(%{uri | query: nil, fragment: nil})


### PR DESCRIPTION
## Summary

- preserve leading-`#` package import specifiers when separating asset queries
- allow the existing package `imports` resolver to select browser/default targets instead of emitting unresolved aliases
- add URL and executable ESM regressions covering the vfile-style `#minpath` mapping

## Validation

- `mix test apps/duskmoon_bundler/test` (448 tests, 2 doctests)
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `git diff --check`

Fixes #134